### PR TITLE
Use config.ini for configuration

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,6 @@
+# Config file for the Optech Taproot workshop
+
+[path]
+# Set this to the source directory for your Optech Taproot Bitcoin Core
+# eg SOURCE_DIRECTORY=/Users/Optech/bitcoin
+SOURCE_DIRECTORY=

--- a/util.py
+++ b/util.py
@@ -1,18 +1,21 @@
-# Enter your source directory between the quotes here
-SOURCE_DIRECTORY = ''
+import argparse
+import configparser
+import os
+import sys
+
+# Read configuration from config.ini
+config = configparser.ConfigParser()
+configfile = os.path.abspath(os.path.dirname(__file__)) + "/config.ini"
+config.read_file(open(configfile, encoding="utf8"))
+
+SOURCE_DIRECTORY = config["path"]["SOURCE_DIRECTORY"]
 
 assert not SOURCE_DIRECTORY == '', 'SOURCE_DIRECTORY not configured'
 
 print("Source directory configured as {}".format(SOURCE_DIRECTORY))
 
-import sys
+# Import TestFramework
 sys.path.insert(0, SOURCE_DIRECTORY + '/test/functional')
-
-#############################################################################
-
-import argparse
-import os
-
 from test_framework.test_framework import BitcoinTestFramework
 
 # TestWrapper utility class.


### PR DESCRIPTION
This separates the utils from the configuration. Config now lives in a config.ini file that only needs to be set once. Users do not need to look in the util.py source file.

Developer tip: Once this is merged into master, add `config.ini` to your `.git/info/exclude` file so that your local changes to it don't show up for `git status`, etc.