### PR TITLE
TestWrapper instantiation/setup/shutdown checks

### DIFF
--- a/util.py
+++ b/util.py
@@ -60,6 +60,10 @@ class TestWrapper:
             perf = False,
             randomseed = None):
 
+            if self.running:
+                print("TestWrapper is already running!")
+                return
+
             self.setup_clean_chain = setup_clean_chain
             self.num_nodes = num_nodes
             self.network_thread = network_thread
@@ -86,12 +90,21 @@ class TestWrapper:
             self.options.bitcoincli = bitcoincli
 
             super().setup()
+            self.running = True
+
+        def shutdown(self):
+            if not self.running:
+                print("TestWrapper is not running!")
+            else:
+                super().shutdown()
+                self.running = False
 
     instance = None
 
     def __new__(cls):
         if not TestWrapper.instance:
             TestWrapper.instance = TestWrapper.__TestWrapper()
+            TestWrapper.instance.running = False
         return TestWrapper.instance
 
     def __getattr__(self, name):

--- a/util.py
+++ b/util.py
@@ -18,66 +18,84 @@ print("Source directory configured as {}".format(SOURCE_DIRECTORY))
 sys.path.insert(0, SOURCE_DIRECTORY + '/test/functional')
 from test_framework.test_framework import BitcoinTestFramework
 
-# TestWrapper utility class.
-class TestWrapper(BitcoinTestFramework):
-    """Wrapper Class for BitcoinTestFramework.
+class TestWrapper:
+    """Singleton TestWrapper class.
 
-    Provides the BitcoinTestFramework rpc & daemon process management
-    functionality to external python projects."""
+    This wraps the actual TestWrapper class to ensure that users only ever
+    instantiate a single TestWrapper."""
 
-    def set_test_params(self):
-        # This can be overriden in setup() parameter.
-        self.num_nodes=3
+    class __TestWrapper(BitcoinTestFramework):
+        """Wrapper Class for BitcoinTestFramework.
 
-    def run_test(self):
-        pass
+        Provides the BitcoinTestFramework rpc & daemon process management
+        functionality to external python projects."""
 
-    def setup(self,
-        bitcoind=os.path.abspath(SOURCE_DIRECTORY +  "/src/bitcoind"),
-        bitcoincli=None,
-        setup_clean_chain=True,
-        num_nodes=3,
-        network_thread=None,
-        rpc_timeout=60,
-        supports_cli=False,
-        bind_to_localhost_only=True,
-        nocleanup=False,
-        noshutdown=False,
-        cachedir=os.path.abspath(SOURCE_DIRECTORY + "/test/cache"),
-        tmpdir=None,
-        loglevel='INFO',
-        trace_rpc=False,
-        port_seed=os.getpid(),
-        coveragedir=None,
-        configfile=os.path.abspath(SOURCE_DIRECTORY + "/test/config.ini"),
-        pdbonfailure=False,
-        usecli = False,
-        perf = False,
-        randomseed = None):
+        def set_test_params(self):
+            # This can be overriden in setup() parameter.
+            self.num_nodes=3
 
-        self.setup_clean_chain = setup_clean_chain
-        self.num_nodes = num_nodes
-        self.network_thread = network_thread
-        self.rpc_timeout = rpc_timeout
-        self.supports_cli = supports_cli
-        self.bind_to_localhost_only = bind_to_localhost_only
+        def run_test(self):
+            pass
 
-        self.options = argparse.Namespace
-        self.options.nocleanup = nocleanup
-        self.options.noshutdown = noshutdown
-        self.options.cachedir = cachedir
-        self.options.tmpdir = tmpdir
-        self.options.loglevel = loglevel
-        self.options.trace_rpc = trace_rpc
-        self.options.port_seed = port_seed
-        self.options.coveragedir = coveragedir
-        self.options.configfile = configfile
-        self.options.pdbonfailure = pdbonfailure
-        self.options.usecli = usecli
-        self.options.perf = perf
-        self.options.randomseed = randomseed
+        def setup(self,
+            bitcoind=os.path.abspath(SOURCE_DIRECTORY +  "/src/bitcoind"),
+            bitcoincli=None,
+            setup_clean_chain=True,
+            num_nodes=3,
+            network_thread=None,
+            rpc_timeout=60,
+            supports_cli=False,
+            bind_to_localhost_only=True,
+            nocleanup=False,
+            noshutdown=False,
+            cachedir=os.path.abspath(SOURCE_DIRECTORY + "/test/cache"),
+            tmpdir=None,
+            loglevel='INFO',
+            trace_rpc=False,
+            port_seed=os.getpid(),
+            coveragedir=None,
+            configfile=os.path.abspath(SOURCE_DIRECTORY + "/test/config.ini"),
+            pdbonfailure=False,
+            usecli = False,
+            perf = False,
+            randomseed = None):
 
-        self.options.bitcoind = bitcoind
-        self.options.bitcoincli = bitcoincli
+            self.setup_clean_chain = setup_clean_chain
+            self.num_nodes = num_nodes
+            self.network_thread = network_thread
+            self.rpc_timeout = rpc_timeout
+            self.supports_cli = supports_cli
+            self.bind_to_localhost_only = bind_to_localhost_only
 
-        super(TestWrapper,self).setup()
+            self.options = argparse.Namespace
+            self.options.nocleanup = nocleanup
+            self.options.noshutdown = noshutdown
+            self.options.cachedir = cachedir
+            self.options.tmpdir = tmpdir
+            self.options.loglevel = loglevel
+            self.options.trace_rpc = trace_rpc
+            self.options.port_seed = port_seed
+            self.options.coveragedir = coveragedir
+            self.options.configfile = configfile
+            self.options.pdbonfailure = pdbonfailure
+            self.options.usecli = usecli
+            self.options.perf = perf
+            self.options.randomseed = randomseed
+
+            self.options.bitcoind = bitcoind
+            self.options.bitcoincli = bitcoincli
+
+            super().setup()
+
+    instance = None
+
+    def __new__(cls):
+        if not TestWrapper.instance:
+            TestWrapper.instance = TestWrapper.__TestWrapper()
+        return TestWrapper.instance
+
+    def __getattr__(self, name):
+        return getattr(self.instance, name)
+
+    def __setattr__(self, name):
+        return setattr(self.instance, name)


### PR DESCRIPTION
This PR:

- reimplements `TestWrapper` as a singleton class so that only one object can be instantiated. Any attempts to instantiate a second `TestWrapper` will return the original test wrapper object.
- adds a member variable `running` to ensure that `setup()` has no effect when the test is already running and `shutdown()` has no effect when the test is not running.

Together, these ensure that the user doesn't get into weird states where they have multiple test instances or they try to start tests when the test is already running.