### PR TITLE
Check that no bitcoind processes are running before starting test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 jupyter
+psutil

--- a/util.py
+++ b/util.py
@@ -2,6 +2,7 @@ import argparse
 import configparser
 from io import BytesIO
 import os
+import psutil
 
 from test_framework.messages import (
     COutPoint,
@@ -67,6 +68,12 @@ class TestWrapper:
             if self.running:
                 print("TestWrapper is already running!")
                 return
+
+            # Check whether there are any bitcoind processes running on the system
+            for p in [proc for proc in psutil.process_iter() if 'bitcoin' in proc.name()]:
+                if p.exe().split('/')[-1] == 'bitcoind':
+                    print("bitcoind processes are already running on this system. Please shutdown all bitcoind processes!")
+                    return
 
             self.setup_clean_chain = setup_clean_chain
             self.num_nodes = num_nodes


### PR DESCRIPTION
~This builds on #17. Review that first.~

This PR adds a check to `TestWrapper.setup()` that checks whether there are any bitcoind processes running, and exits early with a message if there are any processes running.

This requires installing and importing [psutil](https://pypi.org/project/psutil/), which is added to `requirements.txt`, so the initial `pip3 install -r requirements.txt` will install it in the virtual environment.

A couple of reasons we might _not_ want this:
- adds another requirement. I don't like asking our attendees to install more than they strictly need to
- requires cross-platform testing