### PR TITLE
Update bitcoind version to Taproot_V0.1

### DIFF
--- a/0.1-test-notebook.ipynb
+++ b/0.1-test-notebook.ipynb
@@ -26,7 +26,7 @@
    "source": [
     "#### Configure your source directory and import the TestWrapper\n",
     "\n",
-    "In the `config.ini` file, enter the source directory for your local Optech taproot (v0.1 tag) bitcoin repo.\n",
+    "In the `config.ini` file, enter the source directory for your local Optech taproot (Taproot_V0.1 tag) bitcoin repo.\n",
     "\n",
     "This will be used to access the TestFramework Python code and the taproot-compatible bitcoind binary.\n",
     "\n",

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ various schnorr signature schemes for preliminary evaluation.
 
 Our Taproot/Schnorr library is an extension of the Bitcoin python test
 framework, located in the dedicated [Optech Bitcoin Taproot
-Branch](https://github.com/bitcoinops/bitcoin/releases/tag/v0.1).
+Branch](https://github.com/bitcoinops/bitcoin/releases/tag/Taproot_V0.1).
 
 *Note: This Library is intended for demonstrative and educational purposes only.*
 
@@ -54,8 +54,8 @@ through the exercises in this repository.
 
 #### Build a taproot-supporting bitcoind
 
-These workbooks require a `bitcoind` built from the [Optech taproot
-branch, v0.1](https://github.com/bitcoinops/bitcoin/releases/tag/v0.1) which
+These workbooks require a `bitcoind` built from the [Optech Taproot
+V0.1 branch](https://github.com/bitcoinops/bitcoin/releases/tag/Taproot_V0.1) which
 supports schnorr and taproot. 
 
 ![workshop_repositories](files/0-repositories-diagram.jpg)
@@ -69,10 +69,10 @@ $ git clone https://github.com/bitcoinops/bitcoin
 
 Note the path where you cloned the bitcoinops/bitcoin repository.
 
-Checkout the Optech taproot branch, which is tagged as `v0.1`:
+Checkout the Optech taproot branch, which is tagged as `Taproot_V0.1`:
 
 ```
-$ git checkout v0.1
+$ git checkout Taproot_V0.1
 ```
 
 Build the Optech Taproot branch of bitcoind locally. See the build documentation


### PR DESCRIPTION
Release tag in bitcoinops/bitcoin has changed name from v0.1 to Taproot_V0.1. Update readme and preparation notebook.