### PR TITLE
Reformatted Musig

### DIFF
--- a/1.2-Introduction-to-Musig.ipynb
+++ b/1.2-Introduction-to-Musig.ipynb
@@ -68,9 +68,9 @@
    "source": [
     "#### 1.2.1 _Programming Exercise:_ Compute 3-of-3 MuSig public key\n",
     "\n",
-    "In this exercise, we'll use the `generate_musig_key()` function to generate challenge factors for each participant and an aggregate MuSig pubkey.\n",
+    "In this exercise, we'll use the `generate_musig_key(pubkey_list)` function to generate challenge factors for each participant and an aggregate MuSig pubkey.\n",
     "\n",
-    "`generate_musig_key()` takes a list of the participants' public keys `generate_musig_key([ECPubKey0, ECPubKey1, ...])` and returns a challenge map and the aggregate pubkey:\n",
+    "`generate_musig_key(pubkey_list)` takes a list of the participants' public keys `generate_musig_key([ECPubKey0, ECPubKey1, ...])` and returns a challenge map and the aggregate pubkey:\n",
     "* the challenge map contains `ECPubKey_i, challenge_data_i` key - value pairs.\n",
     "* The aggregate pubkey is an `ECPubKey` object"
    ]
@@ -123,7 +123,7 @@
     "\n",
     "Individual participants should only exchange their nonce point when they have received all commitments, and only proceed with signing if all nonce points match their commitments.\n",
     "\n",
-    "Finally, if the aggregate nonce is not a quadratic residue, then it is negated and all individual nonce points are also negated."
+    "Finally, if the aggregate nonce is not a quadratic residue, then it is negated and all individual nonces are also negated."
    ]
   },
   {
@@ -141,8 +141,8 @@
     "\n",
     "In this exercise, we'll generate nonces for individual participants, calculate the nonce point commitments, and then generate an aggregate nonce point.\n",
     "\n",
-    "* Use `generate_schnorr_nonce()` to generate a random nonce. The function returns an `ECkey` object which is a valid schnorr nonce (quadratic residue y-value).\n",
-    "* Use `aggregate_schnorr_nonces()` to aggregate those individual nonces. The function takes a list of `ECKey` nonces and returns a the aggregate nonce and a negation flag:\n",
+    "* Use `generate_schnorr_nonce()` to generate a random nonce. The function returns an `ECkey` object which is a valid schnorr nonce.\n",
+    "* Use `aggregate_schnorr_nonces(nonce_point_list)` to aggregate those individual nonces. The function takes a list of `ECKey` nonces and returns a the aggregate nonce and a negation flag:\n",
     "  * the aggregate nonce is an `ECPubKey` object\n",
     "  * the negation flag is a boolean and indicates that the individual nonces should be negated"
    ]
@@ -188,7 +188,7 @@
     "\n",
     "Once all participants have their individual nonces and the aggregate nonce point, then can all sign individually. \n",
     "\n",
-    "The individual `s` values are then exchanged and summed together. The aggregate `s` value and aggregate nonce point `R` form a valid bip-schnorr signature for the aggregate pubkey.\n",
+    "The partial `s` values are then exchanged and summed together. The aggregate `s` value and aggregate nonce point `R` form a valid bip-schnorr signature for the aggregate pubkey.\n",
     "\n",
     "Notice that the hash expressions are identical in all signatures, which makes aggregation possible."
    ]
@@ -206,18 +206,18 @@
    "source": [
     "#### 1.2.3 _Programming exercise:_ Compute aggregated MuSig signature\n",
     "\n",
-    "In this exercise, we'll create individual signatures and then aggregate them to create a valid signature.\n",
+    "In this exercise, we'll create partial signatures and then aggregate them to create a valid signature.\n",
     "\n",
-    "Use the `sign_musig()` function to create individual signatures. `sign_musig()` takes:\n",
+    "Use the `sign_musig()` function to create partial signatures. `sign_musig()` takes:\n",
     "  - the individual participant's challenge-factor-modified private key (an `ECKey` object)\n",
     "  - the invididual participant's nonce scalar (an `ECKey` object)\n",
     "  - the aggregate nonce point (an `ECPubKey` object)\n",
     "  - the aggregate pubkey (an `ECPubKey` object)\n",
     "  - the message (a 32 byte `bytes` object)\n",
     "\n",
-    "and returns an individual signature (a 64 byte `bytes` object containing `R(x)` and `s`).\n",
+    "and returns a partial signature (an int containing the partial `s` value).\n",
     "\n",
-    "Use `aggregate_musig_signatures()` to aggregate the individual signatures. `aggregate_musig_signatures()` takes a list of signatures and returns the aggregated signature.\n",
+    "Use `aggregate_musig_signatures()` to aggregate the partial signatures. `aggregate_musig_signatures()` takes a list of partial signatures, and the aggregate nonce point and returns the final signature.\n",
     "\n",
     "Use `ECPubKey.verify_schnorr(sig, msg)` to verify that the signature is valid."
    ]
@@ -230,12 +230,12 @@
    "source": [
     "msg = hashlib.sha256(b'transaction').digest()\n",
     "\n",
-    "# Generate individual signatures\n",
-    "sig0 =  # TODO: implement\n",
-    "sig1 =  # TODO: implement\n",
-    "sig2 =  # TODO: implement\n",
+    "# Generate partial signatures.\n",
+    "s0 =  # TODO: implement\n",
+    "s1 =  # TODO: implement\n",
+    "s2 =  # TODO: implement\n",
     "\n",
-    "# Aggregate signatures\n",
+    "# Aggregate partial signatures\n",
     "sig_agg =  # TODO: implement\n",
     "\n",
     "# Verify signature\n",

--- a/solutions/1.2-Introduction-to-Musig-Solutions.txt
+++ b/solutions/1.2-Introduction-to-Musig-Solutions.txt
@@ -62,13 +62,13 @@ print("R_agg was negated:", negated)
 ```
 msg = hashlib.sha256(b'transaction').digest()
 
-# Generate individual signatures
-sig0 = sign_musig(privkey0_c, k0, R_agg, pubkey_musig, msg)
-sig1 = sign_musig(privkey1_c, k1, R_agg, pubkey_musig, msg)
-sig2 = sign_musig(privkey2_c, k2, R_agg, pubkey_musig, msg)
+# Generate partial signatures
+s0 = sign_musig(privkey0_c, k0, R_agg, pubkey_musig, msg)
+s1 = sign_musig(privkey1_c, k1, R_agg, pubkey_musig, msg)
+s2 = sign_musig(privkey2_c, k2, R_agg, pubkey_musig, msg)
 
-# Aggregate signatures
-sig_agg = aggregate_musig_signatures([sig0, sig1, sig2])
+# Aggregate partial signatures
+sig_agg = aggregate_musig_signatures([s0, s1, s2], R_agg)
 
 # Verify signature
 assert pubkey_musig.verify_schnorr(sig_agg, msg)

--- a/solutions/2.1-Segwit-Version-1-Solutions.txt
+++ b/solutions/2.1-Segwit-Version-1-Solutions.txt
@@ -64,9 +64,9 @@ nonce2 = generate_schnorr_nonce()
 R_agg, negated = aggregate_schnorr_nonces([nonce1.get_pubkey(), nonce2.get_pubkey()])
 
 # Create an aggregate signature
-sig1 = sign_musig(privkey1_c, nonce1, R_agg, agg_pubkey, sighash_musig)
-sig2 = sign_musig(privkey2_c, nonce2, R_agg, agg_pubkey, sighash_musig)
-sig_agg = aggregate_musig_signatures([sig1, sig2])
+s1 = sign_musig(privkey1_c, nonce1, R_agg, agg_pubkey, sighash_musig)
+s2 = sign_musig(privkey2_c, nonce2, R_agg, agg_pubkey, sighash_musig)
+sig_agg = aggregate_musig_signatures([s1, s2], R_agg)
 print("Aggregate signature is {}\n".format(sig_agg.hex()))
 
 # Construct transaction witness

--- a/solutions/2.2-TapTweak-Solutions.txt
+++ b/solutions/2.2-TapTweak-Solutions.txt
@@ -38,9 +38,9 @@ msg = hashlib.sha256(b'msg').digest()
 privkey0_c_tweaked = privkey0_c.add(tweak) 
 
 # Sign individually and then aggregate signatures
-sig0 = sign_musig(privkey0_c_tweaked, k0, R_agg, agg_pubkey_tweaked, msg)
-sig1 = sign_musig(privkey1_c, k1, R_agg, agg_pubkey_tweaked, msg)
-sig_agg = aggregate_musig_signatures([sig0, sig1])
+s0 = sign_musig(privkey0_c_tweaked, k0, R_agg, agg_pubkey_tweaked, msg)
+s1 = sign_musig(privkey1_c, k1, R_agg, agg_pubkey_tweaked, msg)
+sig_agg = aggregate_musig_signatures([s0, s1], R_agg)
 
 assert agg_pubkey_tweaked.verify_schnorr(sig_agg, msg)
 print("Success!")


### PR DESCRIPTION
Rephrased "individual signatures" to "partial signatures".
Changed `sign_musig()` to return just the `s` as an int.
Changed `aggregate_musig_signatures()` to accept a list of *int* s's and the aggregated R,