### PR TITLE
Fix mistake in deterministic nonce section

### DIFF
--- a/1.1-Introduction-to-Schnorr.ipynb
+++ b/1.1-Introduction-to-Schnorr.ipynb
@@ -244,7 +244,7 @@
     "print(\"pubkey = {}\\n\".format(P.get_bytes().hex()))\n",
     "\n",
     "# Generate the nonce value k deterministically and get the nonce point R\n",
-    "# Method: use hashlib.sha256(bytes).digest() on the message and pubkey\n",
+    "# Method: use hashlib.sha256(bytes).digest() on the message and private key\n",
     "k_bytes =  # TODO: implement\n",
     "k, R =  # TODO: implement\n",
     "\n",


### PR DESCRIPTION
Generate the deterministic nonce using the private key and the message, not the public key and the message.