### PR TITLE
Add 0.3 Tagged Hashes

### DIFF
--- a/0.3-tagged-hashes.ipynb
+++ b/0.3-tagged-hashes.ipynb
@@ -1,0 +1,95 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from test_framework.script import sha256"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 0.3 Tagged Hashes\n",
+    "\n",
+    "Tagged Hashes are cryptographic hash functions that are used throughout the schnorr/taproot specifications. Their purpose is to make sure that hashes used in one context can't be used in another context. This avoids issues like [CVE-2012-2459](https://en.bitcoin.it/wiki/Common_Vulnerabilities_and_Exposures#CVE-2012-2459), where an internal node in a merkle tree could be reinterpreted as a leaf node, or vice versa.\n",
+    "\n",
+    "[BIP-schnorr](https://github.com/sipa/bips/blob/bip-schnorr/bip-schnorr.mediawiki) outlines an example concern:\n",
+    "\n",
+    "> For example, without tagged hashing, a bip-schnorr signature could also be valid for a signature scheme where the only difference is that the arguments to the hash function are reordered. Worse, if the bip-schnorr nonce derivation function was copied or independently created, then the nonce could be accidentally reused in the other scheme leaking the secret key.\n",
+    "\n",
+    "Tagged hash functions are obtained by prefixing the preimage with `sha256(TagName) || sha256(TagName)` and then hashing as normal:\n",
+    "\n",
+    "**`tagged_hash(\"TagName\")`** = `sha256(sha256(\"TagName\") + sha256(\"TagName\") + data)`\n",
+    "\n",
+    "The tag name is dependent on context. For example, the hash function in bip-schnorr uses the tag **BIPSchnorr**, and the hash function used for a branch in a taproot tree uses the tag **TapLeaf**.\n",
+    "\n",
+    "The prefixed, context-dependent tag data makes hash collisions between different domains infeasible.\n",
+    "\n",
+    "The proposal suggests to hash the tag twice because:\n",
+    "\n",
+    "> this is a 64-byte long context-specific constant and the SHA256 block size is also 64 bytes, optimized implementations are possible (identical to SHA256 itself, but with a modified initial state). Using SHA256 of the tag name itself is reasonably simple and efficient for implementations that don't choose to use the optimization.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### _0.3.1 Programming Exercise:_ Implement a tagged hash function\n",
+    "Complete the implementation of the `tagged_hash` function in Python."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def tagged_hash(tag, input_data):\n",
+    "    # Hash \"TagName\" using SHA256\n",
+    "    tag_digest = sha256(tag)\n",
+    "    # The preimage becomes sha256(\"TagName\") + sha256(\"TagName\") + data\n",
+    "    preimage =  # TODO: implement\n",
+    "    return sha256(preimage)\n",
+    "\n",
+    "h = tagged_hash(b'SampleTagName', b'Input data')\n",
+    "\n",
+    "assert h.hex() == \"4c55df56134d7f37d3295850659f2e3729128c969b3386ec661feb7dfe29a99c\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Congratulations!** You've learned:\n",
+    "\n",
+    "- What tagged hashes are, and why they're used\n",
+    "- How to implement tagged hashes"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/2.3-tapscript.ipynb
+++ b/2.3-tapscript.ipynb
@@ -49,10 +49,10 @@
     "\n",
     "If the internal key of the taproot is a MuSig key, then a committed tapscript is considered an alternative, enforcing spending path, which can impose a separate set of spending conditions independent of the MuSig key. If all participants agree that the locking conditions of the tapscript can be spent, they can collaboratively spend along the MuSig key path, thereby increasing privacy and saving transaction costs.\n",
     "\n",
-    "* __Part 3: Committing scripts into taptweaks__ (Proposed)\n",
-    "    * Tagged Hashing\n",
+    "* __Part 3: Committing scripts into taptweaks__\n",
+    "    * TapTweak: Tagged pubkey tweaks\n",
     "    * TapLeaf: Tagged tapscript hashes\n",
-    "    * Spending a single tapscript commitment\n"
+    "    * Spending a single tapscript commitment"
    ]
   },
   {
@@ -458,17 +458,11 @@
    "source": [
     "## Part 3: Committing scripts into taptweaks\n",
     "\n",
-    "### Tagged hashes\n",
+    "### TapTweaks\n",
     "\n",
-    "In chapter 2.2, we learned that it is possible to make valid commitments to a public key, which are called taptweaks. A taptweak commitment is computed with tagged hashes.\n",
+    "In chapter 2.2, we learned that it is possible to make valid commitments to a public key, which are called taptweaks. A taptweak commitment is computed with a tagged hash using the **TapTweak** tag.\n",
     "\n",
-    "* **`TapTweak`** = `sha256(sha256(\"TapTweak\") + sha256(\"TapTweak\") + commitment_hash)`\n",
-    "    \n",
-    "More generally, we can use this function to create tagged hashes, which are described in [bip-schnorr](https://github.com/sipa/bips/blob/bip-schnorr/bip-taproot.mediawiki) and [bip-taproot](https://github.com/sipa/bips/blob/bip-schnorr/bip-taproot.mediawiki). \n",
-    "\n",
-    "* **`tagged_hash(\"Tag\")`** = `sha256(sha256(\"Tag\") + sha256(\"Tag\") + data)`\n",
-    " \n",
-    "Tagged hashes have the advantages that they provide higher collision resistance. The 64B, duplicated sha256(\"Tag\") expression lends itself to optimization in tagged hash implementations. "
+    "* **`TapTweak`** = `tagged_hash(\"TapTweak\", commitment_hash)`"
    ]
   },
   {

--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ provided by jupyter notebook server in the terminal.
 - Verify that `0.1-test-notebook.ipynb` passes all checks.
 
 After you have run the 0.1 example exercises, please also run through the
-0.2-Elliptic-Curve-Math.ipynb notebook and exercises before the workshop. 
+0.2-elliptic-curve-math.ipynb and 0.3-tagged-hashes.ipynb notebooks and
+exercises before the workshop. 
 
 Notebooks 1.x, 2.x, etc will be covered during the workshop. There is no need to
 run through those beforehand.

--- a/solutions/0.3-tagged-hashes-solutions.ipynb
+++ b/solutions/0.3-tagged-hashes-solutions.ipynb
@@ -1,0 +1,50 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### _0.3.1 Programming Exercise:_ Implement a tagged hash function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def tagged_hash(tag, input_data):\n",
+    "    # Hash \"TagName\" using SHA256\n",
+    "    tag_digest = sha256(tag)\n",
+    "    # The preimage becomes sha256(\"TagName\") + sha256(\"TagName\") + data\n",
+    "    preimage = tag_digest + tag_digest + input_data\n",
+    "    return sha256(preimage)\n",
+    "\n",
+    "h = tagged_hash(b'SampleTagName', b'Input data')\n",
+    "\n",
+    "assert h.hex() == \"4c55df56134d7f37d3295850659f2e3729128c969b3386ec661feb7dfe29a99c\""
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION

- adds 0.3 notebook for tagged hashes
- removes introductory tagged hash content from 2.3
- adds reference to 0.3 in README

Addresses https://github.com/bitcoinops/taproot-workshop/issues/91