### PR TITLE
Adds guards to ensure TapTree internal key is set.

### DIFF
--- a/test_framework/script.py
+++ b/test_framework/script.py
@@ -1114,16 +1114,14 @@ class TapTree:
 
     @property
     def desc(self):
-        if self.key.is_valid and self.root!= None:
-            res = 'tp(' +  self.key.get_bytes().hex() + ','
-            res += TapTree._encode_tree(self.root)
-            res += ')'
-            return res
-        else:
-            # TODO: Exception message.
-            raise Exception
+        assert self.key.valid == True, "Valid internal key must be set."
+        res = 'tp(' +  self.key.get_bytes().hex() + ','
+        res += TapTree._encode_tree(self.root)
+        res += ')'
+        return res
 
     def construct(self):
+        assert self.key.valid == True, "Valid internal key must be set."
         ctrl, h = self._constructor(self.root)
         tweak = TaggedHash("TapTweak", self.key.get_bytes() + h)
         control_map = dict((script, GetVersionTaggedPubKey(self.key, version) + control) for version, script, control in ctrl)


### PR DESCRIPTION
Addresses [#43](https://github.com/bitcoinops/taproot-workshop/issues/43#issue-496024655).