### PR TITLE
[WIP] Add test setup convenience methods

### DIFF
--- a/2.0-taproot-introduction.ipynb
+++ b/2.0-taproot-introduction.ipynb
@@ -1,0 +1,359 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import util\n",
+    "from test_framework.address import program_to_witness\n",
+    "from test_framework.key import generate_key_pair\n",
+    "from test_framework.messages import COutPoint, CTransaction, CTxIn, CTxOut, CScriptWitness, CTxInWitness\n",
+    "from test_framework.script import SegwitV0SignatureHash, SIGHASH_ALL, hash160, get_p2pkh_script"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 2.0 Taproot Introduction\n",
+    "\n",
+    "Over the following chapters, we introduce various aspects of the schnorr/taproot soft fork proposal. Each chapter is built around a case study, demonstrating how the technology can be used in world applications.\n",
+    "\n",
+    "In each chapter, we first introduce the case study scenario and give an overview of the technology. We then demonstrate its use as follows:\n",
+    "\n",
+    "1. We first construct a segwit v1 witness program that implements the desired spending policy and derive the bech32 address for that witness program;\n",
+    "2. Then we start a Bitcoin Core full node, generate 101 blocks on the node (so that the node has a mature balance to spend), and spend coins from the Bitcoin Core wallet to the bech32 address from step (1);\n",
+    "3. Finally, we construct a transaction spending from the output created in step (2) back to the Bitcoin Core wallet. We sign the transaction and verify that the transaction is valid using the full node's `testmempoolaccept` RPC method.\n",
+    "\n",
+    "This sequence of steps is illustrated below:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![test](images/segwit_version1_1.jpg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In each chapter, we'll implement the spending policy using both v0 (pre-taproot) segwit and v1 (taproot) segwit outputs, and highlight the differences in transaction weight and privacy."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Transaction sequence\n",
+    "\n",
+    "This chapter demonstrates the transaction sequence in full detail. Future chapters follow the same steps, but use convenience functions to abstract away the low-level details."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example 2.0.1 Generate a segwit v0 bech32 address\n",
+    "\n",
+    "We generate an address *outside* the Bitcoin Core wallet, which we'll send funds to from Bitcoin Core.\n",
+    "\n",
+    "In this example, we'll use a P2WPKH segwit output (not a taproot output)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate a new key pair\n",
+    "privkey, pubkey = generate_key_pair()\n",
+    "print(\"Pubkey: {}\\n\".format(pubkey.get_bytes().hex()))\n",
+    "\n",
+    "# Get the hash160 of the public key for the witness program\n",
+    "program = hash160(pubkey.get_bytes())\n",
+    "print(\"Witness program: {}\\n\".format(program.hex()))\n",
+    "\n",
+    "# Create (regtest) bech32 address\n",
+    "version = 0x00\n",
+    "address = program_to_witness(version, program)\n",
+    "print(\"bech32 address: {}\".format(address))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example 2.0.2 Start a Bitcoin Core node, then generate blocks and send output to the bech32 address generated above\n",
+    "\n",
+    "This functionality will be encapsulated in the `node.generate_and_send_coins(address)` method later."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Start node\n",
+    "test = util.TestWrapper()\n",
+    "test.setup()\n",
+    "node = test.nodes[0]\n",
+    "\n",
+    "version = node.getnetworkinfo()['subversion']\n",
+    "print(\"\\nClient version is {}\\n\".format(version))\n",
+    "\n",
+    "# Generate 101 blocks\n",
+    "node.generate(101)\n",
+    "balance = node.getbalance()\n",
+    "print(\"Balance: {}\\n\".format(balance))\n",
+    "\n",
+    "assert balance > 1\n",
+    "\n",
+    "unspent_txid = node.listunspent(1)[-1][\"txid\"]\n",
+    "inputs = [{\"txid\": unspent_txid, \"vout\": 0}]\n",
+    "\n",
+    "# Create a raw transaction sending 1 BTC to the address and then sign it.\n",
+    "tx_hex = node.createrawtransaction(inputs=inputs, outputs=[{address: 1}])\n",
+    "res = node.signrawtransactionwithwallet(hexstring=tx_hex)\n",
+    "\n",
+    "tx_hex = res[\"hex\"]\n",
+    "assert res[\"complete\"]\n",
+    "assert 'errors' not in res\n",
+    "\n",
+    "# Send the raw transaction. We haven't created a change output,\n",
+    "# so maxfeerate must be set to 0 to allow any fee rate.\n",
+    "txid = node.sendrawtransaction(hexstring=tx_hex, maxfeerate=0)\n",
+    "\n",
+    "print(\"Transaction {}, output 0\\nsent to {}\".format(txid, address))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example 2.0.3 Construct a transaction to spend the coins back to the Bitcoin Core wallet\n",
+    "\n",
+    "In this example, we'll manually construct a transaction which spends the output back to the Bitcoin Core wallet.\n",
+    "\n",
+    "To do that we create a `CTransaction` object and populate the data members:\n",
+    "\n",
+    " * `nVersion`\n",
+    " * `nLocktime`  \n",
+    " * `tx_vin` (list of `CTxIn` objects)\n",
+    " * `tx_vout` (list of `CTxOut` objects)\n",
+    "\n",
+    "This functionality will be encapsulated in the `test.create_spending_transaction(coin_txid, version)` method later.\n",
+    "\n",
+    "The only item that we don't populate is the witness:\n",
+    " \n",
+    " * `tx.wit.vtxinwit` (list of `CTxInWitness` objects)\n",
+    "\n",
+    "which we'll do later."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Construct transaction\n",
+    "spending_tx = CTransaction()\n",
+    "\n",
+    "# Populate the transaction version\n",
+    "spending_tx.nVersion = 1\n",
+    "\n",
+    "# Populate the locktime\n",
+    "spending_tx.nLockTime = 0\n",
+    "\n",
+    "# Populate the transaction inputs\n",
+    "outpoint = COutPoint(int(txid, 16), 0)\n",
+    "spending_tx_in = CTxIn(outpoint)\n",
+    "spending_tx.vin = [spending_tx_in]\n",
+    "\n",
+    "# Generate new Bitcoin Core wallet address\n",
+    "dest_addr = node.getnewaddress(address_type=\"bech32\")\n",
+    "scriptpubkey = bytes.fromhex(node.getaddressinfo(dest_addr)['scriptPubKey'])\n",
+    "\n",
+    "# Complete output which returns 0.5 BTC to Bitcoin Core wallet\n",
+    "amount_sat = int(0.5 * 100_000_000)\n",
+    "dest_output = CTxOut(nValue=amount_sat, scriptPubKey=scriptpubkey)\n",
+    "spending_tx.vout = [dest_output]\n",
+    "\n",
+    "print(\"Spending transaction:\\n{}\".format(spending_tx))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example 2.0.4 Generate signature for transaction, add it to the witness, and test mempool acceptance.\n",
+    "\n",
+    "In this example, we sign the transaction, add the signature to the transaction's witness, and then use `testmempoolaccept` to verify that the transaction is valid. Later on, we'll use the `node.test_transaction()` convenience method to test mempool acceptance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate the segwit v0 signature hash for signing\n",
+    "sighash = SegwitV0SignatureHash(script=get_p2pkh_script(program),\n",
+    "                                txTo=spending_tx,\n",
+    "                                inIdx=0,\n",
+    "                                hashtype=SIGHASH_ALL,\n",
+    "                                amount=100_000_000)\n",
+    "\n",
+    "# Sign using ECDSA and append the SIGHASH byte\n",
+    "sig = privkey.sign_ecdsa(sighash) + chr(SIGHASH_ALL).encode('latin-1')\n",
+    "\n",
+    "print(\"Signature: {}\\n\".format(sig.hex()))\n",
+    "\n",
+    "# Construct transaction witness. For P2WPKH, the witness is the signature and the pubkey\n",
+    "witness = CScriptWitness()\n",
+    "witness.stack = [sig, pubkey.get_bytes()]\n",
+    "witness_in = CTxInWitness()\n",
+    "witness_in.scriptWitness = witness\n",
+    "\n",
+    "# vtxinwit is a list of the witness data (signatures, etc.)\n",
+    "spending_tx.wit.vtxinwit.append(witness_in)\n",
+    "\n",
+    "print(\"Spending transaction:\\n{}\\n\".format(spending_tx))\n",
+    " \n",
+    "# Serialize signed transaction for broadcast\n",
+    "spending_tx_str = spending_tx.serialize().hex()\n",
+    " \n",
+    "# Test mempool acceptance\n",
+    "assert node.testmempoolaccept(rawtxs=[spending_tx_str], maxfeerate=0)[0]['allowed']\n",
+    "print(\"Success!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example 2.0.5 Shutdown the node\n",
+    "\n",
+    "Finally we run `test.shutdown()` to end the test and shutdown the node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test.shutdown()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example 2.0.6 Repeat the steps using convenience functions\n",
+    "\n",
+    "We'll repeat the set of steps using the convenience functions:\n",
+    "\n",
+    "1. Start the node and create an output that we can spend using `node.generate_and_send_coins(address)`\n",
+    "2. Create a `CTransaction` object that spends the output back to the Bitcoin Core wallet using `test.create_spending_transaction(coin_txid, version)`\n",
+    "3. Manually sign the transaction and add the witness\n",
+    "4. Test mempool acceptance using `node.test_transaction()`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Start node\n",
+    "test = util.TestWrapper()\n",
+    "test.setup()\n",
+    "node = test.nodes[0]\n",
+    "\n",
+    "# Generate coins and create an output\n",
+    "tx = node.generate_and_send_coins(address)\n",
+    "print(\"Transaction {}, output 0\\nsent to {}\\n\".format(tx.hash, address))\n",
+    "\n",
+    "# Create a spending transaction\n",
+    "spending_tx = test.create_spending_transaction(tx.hash)\n",
+    "print(\"Spending transaction:\\n{}\\n\".format(spending_tx))\n",
+    "\n",
+    "# Sign the spending transaction and append the witness\n",
+    "sighash = SegwitV0SignatureHash(script=get_p2pkh_script(program),\n",
+    "                                txTo=spending_tx,\n",
+    "                                inIdx=0,\n",
+    "                                hashtype=SIGHASH_ALL,\n",
+    "                                amount=100_000_000)\n",
+    "sig = privkey.sign_ecdsa(sighash) + chr(SIGHASH_ALL).encode('latin-1')\n",
+    "witness = CScriptWitness()\n",
+    "witness.stack = [sig, pubkey.get_bytes()]\n",
+    "witness_in = CTxInWitness()\n",
+    "witness_in.scriptWitness = witness\n",
+    "spending_tx.wit.vtxinwit.append(witness_in)\n",
+    "\n",
+    "# Test mempool acceptance\n",
+    "assert node.test_transaction(spending_tx)\n",
+    "print(\"Success!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example 2.0.7 Shutdown the node\n",
+    "\n",
+    "As always, we finish by shutting down the node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test.shutdown()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Congratulations!** In this chapter, you have:\n",
+    "\n",
+    "- Started a Bitcoin Core full node (in regtest mode), generated 101 blocks and sent a transaction output to a segwit address\n",
+    "- Constructed a transaction that spends the segwit output back to the wallet, and tested that it is accepted by the mempool\n",
+    "- Repeated the same steps using the `generate_and_send_coins()` and `create_spending_transaction()` convenience functions\n",
+    "\n",
+    "We'll use exactly the same sequence of steps in future chapters to spend to and from segwit v1 addresses."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/2.1-segwit-version-1.ipynb
+++ b/2.1-segwit-version-1.ipynb
@@ -6,15 +6,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from io import BytesIO\n",
-    "import random\n",
-    "\n",
     "import util\n",
     "from test_framework.address import program_to_witness\n",
-    "from test_framework.key import ECKey, ECPubKey, generate_key_pair, generate_schnorr_nonce\n",
-    "from test_framework.messages import CTransaction, COutPoint, CTxIn, CTxOut, CScriptWitness, CTxInWitness, sha256\n",
-    "from test_framework.musig import generate_musig_key, aggregate_schnorr_nonces, sign_musig, aggregate_musig_signatures\n",
-    "from test_framework.script import CScript, OP_1, TaprootSignatureHash, SIGHASH_ALL_TAPROOT"
+    "from test_framework.key import generate_key_pair, generate_schnorr_nonce\n",
+    "from test_framework.messages import CScriptWitness, CTxInWitness\n",
+    "from test_framework.musig import aggregate_musig_signatures, aggregate_schnorr_nonces, generate_musig_key, sign_musig\n",
+    "from test_framework.script import SIGHASH_ALL_TAPROOT, TaprootSignatureHash"
    ]
   },
   {
@@ -37,9 +34,7 @@
     "\n",
     "The first half of this chapter shows an example of sending funds to a segwit v1 address using the Bitcoin Core wallet, and then manually constructing a transaction that spends that output using the new bip-taproot key path spending rules.\n",
     "\n",
-    "![test](images/segwit_version1_1.jpg)\n",
-    "\n",
-    "There is then a coding exercise to send funds to a MuSig aggregate pubkey address, and then construct a transaction that spends from that address using the bip-taproot key path spending rules, which follows the same "
+    "There is then a coding exercise to send funds to a MuSig aggregate pubkey address, and then construct a transaction that spends from that address using the bip-taproot key path spending rules, following the same steps as the example."
    ]
   },
   {
@@ -119,7 +114,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Example 2.1.2: Startup TestWrapper to initialize a regtest node and wallet\n",
+    "#### Example 2.1.2: Start Bitcoin Core node and send coins to the taproot address\n",
+    "\n",
     "Only run setup once, or after a clean shutdown."
    ]
   },
@@ -129,71 +125,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Start node\n",
     "test = util.TestWrapper()\n",
     "test.setup()\n",
+    "node = test.nodes[0]\n",
     "\n",
-    "version = test.nodes[0].getnetworkinfo()['subversion']\n",
-    "print(\"\\nClient version is {}\".format(version))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Example 2.1.3: Generate coins for the wallet"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "test.nodes[0].generate(101)\n",
-    "balance = test.nodes[0].getbalance()\n",
-    "print('Balance: {}'.format(balance))\n",
-    "\n",
-    "assert balance > 1"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Example 2.1.4: Send funds from the Bitcoin Core wallet to the segwit address"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Send wallet transaction to segwit address\n",
-    "amount_btc = 0.05\n",
-    "txid = test.nodes[0].sendtoaddress(address, amount_btc)\n",
-    "\n",
-    "# Decode wallet transaction\n",
-    "tx_hex = test.nodes[0].getrawtransaction(txid) \n",
-    "decoded_tx = test.nodes[0].decoderawtransaction(tx_hex)\n",
-    "\n",
-    "print(\"Transaction:\\n{}\\n\".format(decoded_tx))\n",
-    "\n",
-    "# Reconstruct wallet transaction locally\n",
-    "tx = CTransaction()\n",
-    "tx.deserialize(BytesIO(bytes.fromhex(tx_hex)))\n",
-    "tx.rehash()\n",
-    "\n",
-    "# We can check if the transaction was correctly deserialized\n",
-    "assert txid == decoded_tx[\"txid\"]\n",
-    "\n",
-    "# The wallet randomizes the change output index for privacy\n",
-    "# Loop through the outputs and return the first where the scriptPubKey matches the segwit v1 output\n",
-    "output_index, output = next(out for out in enumerate(tx.vout) if out[1].scriptPubKey == CScript([OP_1, program]))\n",
-    "\n",
-    "print(\"Segwit v1 output is {}\".format(output))\n",
-    "print(\"Segwit v1 output value is {}\".format(output.nValue))\n",
-    "print(\"Segwit v1 output index is {}\".format(output_index))"
+    "# Generate coins and create an output\n",
+    "tx = node.generate_and_send_coins(address)\n",
+    "print(\"Transaction {}, output 0\\nsent to {}\\n\".format(tx.hash, address))"
    ]
   },
   {
@@ -217,7 +156,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Example 2.1.5: Construct `CTransaction` and populate inputs"
+    "#### Example 2.1.3: Construct `CTransaction` and populate fields\n",
+    "\n",
+    "We use the `create_spending_transaction(node, txid)` convenience function."
    ]
   },
   {
@@ -226,20 +167,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Construct transaction\n",
-    "spending_tx = CTransaction()\n",
-    "\n",
-    "# Populate the transaction version\n",
-    "spending_tx.nVersion = 1\n",
-    "\n",
-    "# Populate the locktime\n",
-    "spending_tx.nLockTime = 0\n",
-    "\n",
-    "# Populate the transaction inputs\n",
-    "outpoint = COutPoint(tx.sha256, output_index)\n",
-    "spending_tx_in = CTxIn(outpoint)\n",
-    "spending_tx.vin = [spending_tx_in]\n",
-    "\n",
+    "# Create a spending transaction\n",
+    "spending_tx = test.create_spending_transaction(tx.hash)\n",
     "print(\"Spending transaction:\\n{}\".format(spending_tx))"
    ]
   },
@@ -247,37 +176,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Example 2.1.6: Populate outputs\n",
-    "\n",
-    "We'll generate an output address in the Bitcoin Core wallet to send the funds to, determine the fee, and then populate the spending_tx with an output to that address."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Generate new Bitcoin Core wallet address\n",
-    "dest_addr = test.nodes[0].getnewaddress(address_type=\"bech32\")\n",
-    "scriptpubkey = bytes.fromhex(test.nodes[0].getaddressinfo(dest_addr)['scriptPubKey'])\n",
-    "\n",
-    "# Determine minimum fee required for mempool acceptance\n",
-    "min_fee = int(test.nodes[0].getmempoolinfo()['mempoolminfee'] * 100000000)\n",
-    "\n",
-    "# Complete output which returns funds to Bitcoin Core wallet\n",
-    "amount_sat = int(amount_btc * 100000000)\n",
-    "dest_output = CTxOut(nValue=amount_sat - min_fee, scriptPubKey=scriptpubkey)\n",
-    "spending_tx.vout = [dest_output]\n",
-    "\n",
-    "print(\"Spending transaction:\\n{}\".format(spending_tx))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Example 2.1.7: Sign the transaction with a schnorr signature\n",
+    "#### Example 2.1.4: Sign the transaction with a schnorr signature\n",
     "\n",
     "bip-taproot defines the following sighash flags:\n",
     "* Legacy sighash flags:\n",
@@ -288,7 +187,7 @@
     "  * `0x82` - **SIGHASH_NONE | SIGHASH_ANYONECANPAY**\n",
     "  * `0x83` - **SIGHASH_SINGLE | SIGHASH_ANYONECANPAY**\n",
     "* New sighash flag:\n",
-    "  * `0x00` - same semantics `0x01` **SIGHASH_ALL**\n",
+    "  * `0x00` - **SIGHASH_ALL_TAPROOT** same semantics `0x01` **SIGHASH_ALL**\n",
     "\n",
     "Append the sighash flag to the signature `[R_x, s]` with the sighash byte if not `0x00`."
    ]
@@ -301,7 +200,7 @@
    "source": [
     "# Generate the taproot signature hash for signing\n",
     "# SIGHASH_ALL_TAPROOT is 0x00\n",
-    "sighash = TaprootSignatureHash(spending_tx, [output], SIGHASH_ALL_TAPROOT, input_index=0)\n",
+    "sighash = TaprootSignatureHash(spending_tx, [tx.vout[0]], SIGHASH_ALL_TAPROOT, input_index=0)\n",
     " \n",
     "# All schnorr sighashes except SIGHASH_ALL_TAPROOT require\n",
     "# the hash_type appended to the end of signature\n",
@@ -314,7 +213,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Example 2.1.8: Add the witness and test acceptance of the transaction"
+    "#### Example 2.1.5: Add the witness and test acceptance of the transaction"
    ]
   },
   {
@@ -334,11 +233,8 @@
     "\n",
     "print(\"Spending transaction:\\n{}\\n\".format(spending_tx))\n",
     " \n",
-    "# Serialize signed transaction for broadcast\n",
-    "spending_tx_str = spending_tx.serialize().hex()\n",
-    " \n",
     "# Test mempool acceptance\n",
-    "assert test.nodes[0].testmempoolaccept([spending_tx_str])[0]['allowed']\n",
+    "node.test_transaction(spending_tx)\n",
     "print(\"Success!\")"
    ]
   },
@@ -346,7 +242,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Shutdown the TestWrapper (and all bitcoind instances)**"
+    "#### Example 2.1.6: Shutdown the TestWrapper (and all bitcoind instances)"
    ]
   },
   {
@@ -373,27 +269,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Start the TestWrapper (and bitcoind node)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "test = util.TestWrapper()\n",
-    "test.setup()\n",
-    "\n",
-    "version = test.nodes[0].getnetworkinfo()['subversion']\n",
-    "print(\"\\nClient version is {}\".format(version))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### 2.1.9 _Programming Exercise:_ Generate segwit v1 addresses for a 2-of-2 MuSig aggregate pubkey\n",
+    "#### 2.1.7 _Programming Exercise:_ Generate segwit v1 addresses for a 2-of-2 MuSig aggregate pubkey\n",
     "\n",
     "In this exercise, we create a 2-of-2 aggregate MuSig public key"
    ]
@@ -429,7 +305,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Example 2.1.10: Create a transaction in the Bitcoin Core wallet sending outputs to the segwit v1 addresses"
+    "#### Example 2.1.8: Create a transaction in the Bitcoin Core wallet sending outputs to the segwit v1 addresses"
    ]
   },
   {
@@ -438,39 +314,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Generate coins in Bitcoin Core wallet\n",
-    "blocks = test.nodes[0].generate(101)\n",
-    "balance = test.nodes[0].getbalance()\n",
-    "print('Balance:', balance)\n",
+    "test = util.TestWrapper()\n",
+    "test.setup()\n",
+    "node = test.nodes[0]\n",
     "\n",
-    "# Create Bitcoin Core wallet transaction sending to the MuSig segwit v1 address\n",
-    "amount_btc = 0.05\n",
-    "txid = test.nodes[0].sendmany(amounts={address_musig: amount_btc})\n",
-    "\n",
-    "# Reconstruct wallet transactions locally\n",
-    "tx_hex = test.nodes[0].getrawtransaction(txid)\n",
-    "\n",
-    "tx_musig = CTransaction()\n",
-    "tx_musig.deserialize(BytesIO(bytes.fromhex(tx_hex)))\n",
-    "\n",
-    "# Rehash recalculates the txid (needed later)\n",
-    "tx_musig.rehash()\n",
-    "\n",
-    "print(\"Transaction:\\n{}\\n\".format(tx_musig))\n",
-    "\n",
-    "# Loop through outputs and find the MuSig output\n",
-    "output_index, output = next(out for out in enumerate(tx_musig.vout) if out[1].scriptPubKey == CScript([OP_1, program_musig]))\n",
-    "\n",
-    "print(\"MuSig output is {}\".format(output))\n",
-    "print(\"MuSig output value is {}\".format(output.nValue))\n",
-    "print(\"MuSig output index is {}\".format(output_index))"
+    "# Generate coins and create an output\n",
+    "tx = node.generate_and_send_coins(address_musig)\n",
+    "print(\"Transaction {}, output 0\\nsent to {}\\n\".format(tx.hash, address_musig))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 2.1.11 _Programming Exercise:_ Instantiate a CTransaction object and populate the version, locktime and inputs"
+    "#### Example 2.1.9 : Construct CTransaction and populate fields"
    ]
   },
   {
@@ -479,34 +336,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Construct transaction which spends the musig segwit v1 output\n",
-    "spending_tx = CTransaction()\n",
-    "spending_tx.nVersion =  # TODO: implement\n",
-    "spending_tx.nLockTime =  # TODO: implement\n",
-    "spending_tx.vin =  # TODO: implement\n",
-    "\n",
-    "# Generate new Bitcoin Core wallet address\n",
-    "# Method: addr_string = test.nodes[0].getnewaddress(address_type=\"bech32\")\n",
-    "# Method: decode addr_string with test.nodes[0].getaddressinfo(addr_string)\n",
-    "dest_addr =  # TODO: implement\n",
-    "scriptpubkey =  # TODO: implement\n",
-    "print(\"Destination address: {}\\n\".format(dest_addr))\n",
-    "\n",
-    "# Determine minimum fee required for mempool acceptance\n",
-    "min_fee = int(test.nodes[0].getmempoolinfo()['mempoolminfee'] * 100000000)\n",
-    "\n",
-    "# Complete output which returns funds to Bitcoin Core wallet\n",
-    "# Tip: Construct output with CTxOut(nValue=value_int, scriptPubKey=script_bytes)\n",
-    "# Tip: CTransaction.vout is a list of CTxOut objects.\n",
-    "spending_tx.vout =  # TODO: implement\n",
-    "print(\"Spending transaction:\\n{}\\n\".format(spending_tx))"
+    "# Create a spending transaction\n",
+    "spending_tx = test.create_spending_transaction(tx.hash)\n",
+    "print(\"Spending transaction:\\n{}\".format(spending_tx))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 2.1.12 _Programming Exercise:_ Create a valid bip-schnorr signature for the MuSig aggregate pubkey\n",
+    "#### 2.1.10 _Programming Exercise:_ Create a valid bip-schnorr signature for the MuSig aggregate pubkey\n",
     "\n",
     "In this exercise, we create a signature for the aggregate pubkey, add it to the witness, and then test that the transaction is accepted by the mempool."
    ]
@@ -517,9 +356,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create sighash for ALL.\n",
-    "# Tip: TaprootSignatureHash(tx, [output_list], hash_type = int, input_index = int, scriptpath = bool)\n",
-    "sighash_musig =  # TODO: implement\n",
+    "# Create sighash for ALL (0x00)\n",
+    "sighash_musig = TaprootSignatureHash(spending_tx, [tx.vout[0]], SIGHASH_ALL_TAPROOT, input_index=0)\n",
     "\n",
     "# Generate individual nonces for participants and an aggregate nonce point\n",
     "# Remember to negate the individual nonces if necessary\n",
@@ -544,12 +382,16 @@
     "witness_in.scriptWitness = witness\n",
     "spending_tx.wit.vtxinwit.append(witness_in)\n",
     "\n",
-    "# Serialize Schnorr transaction for broadcast\n",
-    "spending_tx_str = spending_tx.serialize().hex()\n",
-    "\n",
     "# Test mempool acceptance\n",
-    "assert test.nodes[0].testmempoolaccept([spending_tx_str])[0]['allowed']\n",
+    "assert node.test_transaction(spending_tx)\n",
     "print(\"Success!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example 2.1.11: Shutdown the TestWrapper (and all bitcoind instances)"
    ]
   },
   {

--- a/2.2-taptweak.ipynb
+++ b/2.2-taptweak.ipynb
@@ -6,15 +6,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from io import BytesIO\n",
     "import random\n",
     "\n",
     "import util\n",
     "from test_framework.address import program_to_witness\n",
-    "from test_framework.key import ECKey, ECPubKey, SECP256K1_ORDER, generate_key_pair, generate_schnorr_nonce\n",
-    "from test_framework.messages import CTransaction, COutPoint, CTxIn, CTxOut, CScriptWitness, CTxInWitness, ser_string, sha256\n",
+    "from test_framework.key import ECKey, SECP256K1_ORDER, generate_key_pair, generate_schnorr_nonce\n",
+    "from test_framework.messages import CScriptWitness, CTxInWitness, sha256\n",
     "from test_framework.musig import generate_musig_key, aggregate_schnorr_nonces, sign_musig, aggregate_musig_signatures\n",
-    "from test_framework.script import  CScript, OP_1, OP_CHECKSIG, TaprootSignatureHash, TapLeaf, TapTree, Node, SIGHASH_ALL_TAPROOT"
+    "from test_framework.script import TaprootSignatureHash, SIGHASH_ALL_TAPROOT"
    ]
   },
   {
@@ -252,42 +251,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### _Start TestNodes_"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "test = util.TestWrapper()\n",
-    "test.setup()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### _Generate Wallet Balance_"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "test.nodes[0].generate(101)\n",
-    "balance = test.nodes[0].getbalance()\n",
-    "\n",
-    "print(\"Balance: {}\".format(balance))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "#### _Programming Exercise 2.2.5:_ Construct taproot output with tweaked public key"
    ]
   },
@@ -311,17 +274,19 @@
     "\n",
     "# Derive the bech32 address\n",
     "# Tip: set the first byte of taproot_pubkey to 0 or 1 and then call program_to_witness(version_int, pubkey_bytes)\n",
-    "segwit_address =  # TODO: implement\n",
+    "address =  # TODO: implement\n",
     "\n",
-    "assert segwit_address == \"bcrt1pq9lku0vuddzvcte8yvt3xct0dk6cjqeq2yzqp3vwpvh2e8afqpvqqyftl09\"\n",
-    "print(\"Success! Segwit Address: {}\".format(segwit_address))"
+    "assert address == \"bcrt1pq9lku0vuddzvcte8yvt3xct0dk6cjqeq2yzqp3vwpvh2e8afqpvqqyftl09\"\n",
+    "print(\"Success! Address: {}\".format(address))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### _Send funds from the wallet to the taproot output_"
+    "#### Example 2.2.6: Start Bitcoin Core node and send coins to the taproot address\n",
+    "\n",
+    "Only run setup once, or after a clean shutdown."
    ]
   },
   {
@@ -330,55 +295,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Send funds to taproot output\n",
-    "txid = test.nodes[0].sendtoaddress(segwit_address, balance / 100000)\n",
-    "print(\"Funding tx: {}\\n\".format(txid))\n",
+    "# Start node\n",
+    "test = util.TestWrapper()\n",
+    "test.setup()\n",
+    "node = test.nodes[0]\n",
     "\n",
-    "# Deserialize wallet transaction\n",
-    "tx = CTransaction()\n",
-    "tx_hex = test.nodes[0].getrawtransaction(txid)\n",
-    "tx.deserialize(BytesIO(bytes.fromhex(tx_hex)))\n",
-    "tx.rehash()\n",
-    "\n",
-    "# The wallet randomizes the change output index for privacy\n",
-    "# Loop through the outputs and return the first where the scriptPubKey matches the segwit v1 output\n",
-    "output_index, output = next(out for out in enumerate(tx.vout) if out[1].scriptPubKey == CScript([OP_1, taproot_pubkey_v1]))\n",
-    "output_value = output.nValue\n",
-    "\n",
-    "print(\"Segwit v1 output: {}\".format(output))\n",
-    "print(\"Segwit v1 output value: {}\".format(output_value))\n",
-    "print(\"Segwit v1 output index: {}\".format(output_index))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Construct transaction and fill version, locktime and inputs\n",
-    "spending_tx = CTransaction()\n",
-    "spending_tx.nVersion = 1\n",
-    "spending_tx.nLockTime = 0\n",
-    "outpoint = COutPoint(tx.sha256, output_index)\n",
-    "spending_tx_in = CTxIn(outpoint = outpoint)\n",
-    "spending_tx.vin = [spending_tx_in]\n",
-    "print(\"CTransaction: {}\\n\".format(spending_tx))\n",
-    "\n",
-    "# Generate new Bitcoin Core wallet address to send funds to\n",
-    "dest_addr = test.nodes[0].getnewaddress(address_type=\"bech32\")\n",
-    "scriptpubkey = bytes.fromhex(test.nodes[0].getaddressinfo(dest_addr)['scriptPubKey'])\n",
-    "print(\"Sending to address: {}\".format(dest_addr))\n",
-    "\n",
-    "# Determine minimum fee required for mempool acceptance\n",
-    "min_fee = int(test.nodes[0].getmempoolinfo()['mempoolminfee'] * 100000000)"
+    "# Generate coins and create an output\n",
+    "tx = node.generate_and_send_coins(address)\n",
+    "print(\"Transaction {}, output 0\\nsent to {}\\n\".format(tx.hash, address))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### _Programming Exercise 2.2.6:_ Spend taproot output with key path"
+    "#### Example 2.2.7: Construct `CTransaction` and populate inputs\n",
+    "\n",
+    "We use the `create_spending_transaction(node, txid)` convenience function."
    ]
   },
   {
@@ -387,12 +320,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Complete output which returns funds to Bitcoin Core wallet.\n",
-    "dest_output = CTxOut(nValue=output_value-min_fee, scriptPubKey=scriptpubkey)\n",
-    "spending_tx.vout = [dest_output]\n",
-    "\n",
+    "# Create a spending transaction\n",
+    "spending_tx = test.create_spending_transaction(tx.hash)\n",
+    "print(\"Spending transaction:\\n{}\".format(spending_tx))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### _Programming Exercise 2.2.8:_ Spend taproot output with key path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Sign transaction with tweaked private key\n",
-    "# Method: TaprootSignatureHash(tx, output_list, hash_type = int, input_index = int, scriptpath = bool)\n",
+    "# Method: TaprootSignatureHash(tx, output_list, hash_type=int, input_index=int, scriptpath=bool)\n",
     "sighash =  # TODO: implement\n",
     "sig =  # TODO: implement\n",
     "\n",
@@ -403,12 +350,8 @@
     "witness_in.scriptWitness = witness\n",
     "spending_tx.wit.vtxinwit.append(witness_in)\n",
     "\n",
-    "# Serialize transaction for broadcast\n",
-    "# Method: CTransaction.serialize().hex()\n",
-    "spending_tx_str =  # TODO: implement\n",
-    "\n",
     "# Test mempool acceptance\n",
-    "assert test.nodes[0].testmempoolaccept([spending_tx_str])[0]['allowed']\n",
+    "assert node.test_transaction(spending_tx)\n",
     "print(\"Success!\")"
    ]
   },

--- a/2.3-tapscript.ipynb
+++ b/2.3-tapscript.ipynb
@@ -7,15 +7,13 @@
    "outputs": [],
    "source": [
     "import hashlib\n",
-    "from io import BytesIO\n",
     "\n",
     "import util\n",
     "from test_framework.address import program_to_witness\n",
-    "from test_framework.key import ECKey, ECPubKey, generate_key_pair, generate_schnorr_nonce\n",
-    "from test_framework.messages import CTransaction, COutPoint, CTxIn, CTxOut, CScriptWitness, CTxInWitness, sha256\n",
-    "from test_framework.musig import generate_musig_key, aggregate_schnorr_nonces, sign_musig, aggregate_musig_signatures\n",
-    "from test_framework.script import TapLeaf, TapTree, CTransaction, TaprootSignatureHash, CScript, ser_string, OP_1, SIGHASH_ALL_TAPROOT\n",
-    "import test_framework.segwit_addr as segwit_addr"
+    "from test_framework.key import generate_key_pair\n",
+    "from test_framework.messages import CScriptWitness, CTxInWitness, ser_string, sha256\n",
+    "from test_framework.musig import generate_musig_key\n",
+    "from test_framework.script import TapLeaf, TapTree, TaprootSignatureHash, SIGHASH_ALL_TAPROOT"
    ]
   },
   {
@@ -420,10 +418,7 @@
     "print(\"pubkey1: {}\".format(pubkey1.get_bytes().hex()))\n",
     "print(\"pubkey2: {}\\n\".format(pubkey2.get_bytes().hex()))\n",
     "\n",
-    "print(\"pubkey1: {}\".format(pubkey1.get_bytes().hex()))\n",
-    "print(\"pubkey2: {}\\n\".format(pubkey2.get_bytes().hex()))\n",
-    "\n",
-    "# Method: 32B preimage - sha256('sha256', bytes)\n",
+    "# Method: 32B preimage - sha256(bytes)\n",
     "# Method: 20B digest - hashlib.new('ripemd160', bytes).digest()\n",
     "secret = b'secret'\n",
     "preimage =  # TODO: implement\n",
@@ -498,8 +493,7 @@
     "    data += input_data\n",
     "    return sha256(data)\n",
     "\n",
-    "privkey_internal =  # TODO: implement\n",
-    "pubkey_internal =  # TODO: implement\n",
+    "privkey_internal, pubkey_internal =  # TODO: implement\n",
     "\n",
     "# Method: ser_string(Cscript) prepends compact size.\n",
     "TAPSCRIPT_VER = bytes([0xc0])\n",
@@ -578,7 +572,7 @@
     "\n",
     "# Create (regtest) bech32 address\n",
     "version = 0x01\n",
-    "address = segwit_addr.encode(\"bcrt\", version, program)\n",
+    "address = program_to_witness(1, program)\n",
     "print(\"bech32 address is {}\".format(address))"
    ]
   },
@@ -586,9 +580,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Example 2.3.9: Startup TestWrapper to initialize a regtest node and wallet\n",
+    "#### Example 2.3.9: Start Bitcoin Core node and send coins to the taproot address\n",
     "\n",
-    "Run setup only once, or after a clean shutdown."
+    "Only run setup once, or after a clean shutdown."
    ]
   },
   {
@@ -597,82 +591,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Start node\n",
     "test = util.TestWrapper()\n",
     "test.setup()\n",
+    "node = test.nodes[0]\n",
     "\n",
-    "version = test.nodes[0].getnetworkinfo()['subversion']\n",
-    "print(\"Client version is {}\".format(version))"
+    "# Generate coins and create an output\n",
+    "tx = node.generate_and_send_coins(address)\n",
+    "print(\"Transaction {}, output 0\\nsent to {}\\n\".format(tx.hash, address))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "####  Example 2.3.10: Generate coins for the wallet"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "test.nodes[0].generate(101)\n",
-    "balance = test.nodes[0].getbalance()\n",
-    "print('Balance: {}'.format(balance))\n",
+    "#### Example 2.3.10: Construct `CTransaction` and populate fields\n",
     "\n",
-    "assert balance > 1"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Example 2.3.11: Send funds from the Bitcoin Core wallet to the segwit v1 address"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Send wallet transaction to segwit address\n",
-    "amount_btc = 0.05\n",
-    "txid = test.nodes[0].sendtoaddress(address, amount_btc)\n",
-    "\n",
-    "# Decode wallet transaction\n",
-    "tx_hex = test.nodes[0].getrawtransaction(txid) \n",
-    "decoded_tx = test.nodes[0].decoderawtransaction(tx_hex)\n",
-    "\n",
-    "print(\"Transaction:\\n{}\\n\".format(decoded_tx))\n",
-    "\n",
-    "# Reconstruct wallet transaction locally\n",
-    "tx = CTransaction()\n",
-    "tx.deserialize(BytesIO(bytes.fromhex(tx_hex)))\n",
-    "tx.rehash()\n",
-    "\n",
-    "# We can check if the transaction was correctly deserialized\n",
-    "assert txid == decoded_tx[\"txid\"]\n",
-    "\n",
-    "# The wallet randomizes the change output index for privacy\n",
-    "# Loop through the outputs and return the first where the scriptPubKey matches the segwit v1 output\n",
-    "output_index, output = next(out for out in enumerate(tx.vout) if out[1].scriptPubKey == CScript([OP_1, program]))\n",
-    "\n",
-    "print(\"Segwit v1 output is {}\".format(output))\n",
-    "print(\"Segwit v1 output value is {}\".format(output.nValue))\n",
-    "print(\"Segwit v1 output index is {}\".format(output_index))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### _Programming Exercise 2.3.12:_ Construct `CTransaction` and populate inputs\n",
+    "We use the `create_spending_transaction(node, txid, version, nSequence)` convenience function.\n",
     "\n",
     "* Transaction version must set to 2 if the tapscript has set a spend delay.\n",
-    "* The input sequence must be encoded with the required spend delay.\n",
-    "    * `CTxIn(outpoint = ..., nSequence = ...)`"
+    "* The input sequence must be encoded with the required spend delay."
    ]
   },
   {
@@ -681,20 +619,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Construct transaction\n",
-    "spending_tx = CTransaction()\n",
-    "\n",
-    "# Populate the transaction version\n",
-    "spending_tx.nVersion =  # TODO: implement\n",
-    "\n",
-    "# Populate the locktime\n",
-    "spending_tx.nLockTime = 0\n",
-    "\n",
-    "# Populate the transaction inputs\n",
-    "# Method: Construct COutPoint(txid, index)\n",
-    "# Method: Construct CTxIn(outpoint = ..., nSequence = ...)\n",
-    "# Tip: CTransaction.vin = \"list of CTxIn objects\"\n",
-    "spending_tx.vin =  # TODO: implement\n",
+    "# Create a spending transaction\n",
+    "spending_tx = test.create_spending_transaction(tx.hash, version=2, nSequence=delay)\n",
     "\n",
     "print(\"Spending transaction:\\n{}\".format(spending_tx))"
    ]
@@ -703,37 +629,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Example 2.3.13: Populate outputs\n",
-    "\n",
-    "We'll generate an output address in the Bitcoin Core wallet to send the funds to, determine the fee, and then populate the spending tx with an output to that address."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Generate new Bitcoin Core wallet address\n",
-    "dest_addr = test.nodes[0].getnewaddress(address_type=\"bech32\")\n",
-    "scriptpubkey = bytes.fromhex(test.nodes[0].getaddressinfo(dest_addr)['scriptPubKey'])\n",
-    "\n",
-    "# Determine minimum fee required for mempool acceptance\n",
-    "min_fee = int(test.nodes[0].getmempoolinfo()['mempoolminfee'] * 100000000)\n",
-    "\n",
-    "# Complete output which returns funds to Bitcoin Core wallet\n",
-    "amount_sat = int(amount_btc * 100000000)\n",
-    "dest_output = CTxOut(nValue=amount_sat - min_fee, scriptPubKey=scriptpubkey)\n",
-    "spending_tx.vout = [dest_output]\n",
-    "\n",
-    "print(\"Spending transaction:\\n{}\".format(spending_tx))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### _Programming Exercise 2.3.14:_ Sign the transaction\n",
+    "#### _Programming Exercise 2.3.11:_ Sign the transaction\n",
     "\n",
     "Note that we must pass the following arguments to `TaprootSignatureHash` for script path spending:\n",
     "* `scriptpath`: `True`\n",
@@ -748,30 +644,30 @@
    "source": [
     "# Generate the Taproot Signature Hash for signing\n",
     "sighash = TaprootSignatureHash(spending_tx,\n",
-    "                               [output],\n",
+    "                               [tx.vout[0]],\n",
     "                               SIGHASH_ALL_TAPROOT,\n",
     "                               input_index=0,\n",
     "                               scriptpath=  # TODO: implement\n",
     "                               tapscript=  # TODO: implement\n",
     "\n",
     "# Sign with both privkeys\n",
-    "signature0 =  # TODO: implement\n",
     "signature1 =  # TODO: implement\n",
+    "signature2 =  # TODO: implement\n",
     "\n",
-    "print(\"Signature0: {}\".format(signature0.hex()))\n",
-    "print(\"Signature1: {}\".format(signature1.hex()))"
+    "print(\"Signature1: {}\".format(signature1.hex()))\n",
+    "print(\"Signature2: {}\".format(signature2.hex()))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### _Programming Exercise 2.3.15:_ Add the witness and test acceptance of the transaction\n",
+    "#### _Programming Exercise 2.3.12:_ Add the witness and test acceptance of the transaction\n",
     "\n",
     "Remember to revisit the satisfying witness elements for `csahasholder_tapscript` constructed in exercise 2.3.5:\n",
     "* Preimage\n",
+    "* Signature for pubkey2\n",
     "* Signature for pubkey1\n",
-    "* Signature for pubkey0\n",
     "\n",
     "Ensure that the time-lock performs as expected."
    ]
@@ -789,18 +685,16 @@
     "witness.stack =  # TODO: implement\n",
     "witness_in = CTxInWitness()\n",
     "witness_in.scriptWitness = witness\n",
+    "\n",
+    "# vtxinwit is a list of the witness data(i.e. signatures etc.)\n",
     "spending_tx.wit.vtxinwit.append(witness_in)\n",
     "\n",
     "print(\"Spending transaction:\\n{}\\n\".format(spending_tx))\n",
     "\n",
-    "# Serialize signed transaction for broadcast\n",
-    "spending_tx_str = spending_tx.serialize().hex()\n",
-    " \n",
-    "# Test mempool acceptance with and without delay.\n",
-    "assert test.nodes[0].testmempoolaccept([spending_tx_str])[0]['allowed']\n",
-    "assert not test.nodes[0].testmempoolaccept([spending_tx_str])[0]['allowed']\n",
-    "test.nodes[0].generate(delay)\n",
-    "assert test.nodes[0].testmempoolaccept([spending_tx_str])[0]['allowed']\n",
+    "# Test mempool acceptance with and without delay\n",
+    "assert not node.test_transaction(spending_tx)\n",
+    "node.generate(delay)\n",
+    "assert node.test_transaction(spending_tx)\n",
     "\n",
     "print(\"Success!\")"
    ]
@@ -809,7 +703,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Shutdown TestWrapper"
+    "#### Example 2.3.13: Shutdown TestWrapper"
    ]
   },
   {

--- a/2.4-taptree.ipynb
+++ b/2.4-taptree.ipynb
@@ -6,14 +6,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import hashlib\n",
-    "from io import BytesIO\n",
-    "\n",
     "import util\n",
     "from test_framework.address import program_to_witness\n",
-    "from test_framework.key import ECKey, ECPubKey, generate_key_pair\n",
-    "from test_framework.messages import CTransaction, COutPoint, CTxIn, CTxOut, CScriptWitness, CTxInWitness, ser_string, sha256\n",
-    "from test_framework.script import TapTree, TapLeaf, Node, CScript, OP_1, TaprootSignatureHash, OP_CHECKSIG, SIGHASH_ALL_TAPROOT"
+    "from test_framework.key import ECPubKey, generate_key_pair\n",
+    "from test_framework.messages import CScriptWitness, CTxInWitness, ser_string, sha256\n",
+    "from test_framework.script import TapTree, TapLeaf, Node, CScript, TaprootSignatureHash, OP_CHECKSIG, SIGHASH_ALL_TAPROOT"
    ]
   },
   {
@@ -408,7 +405,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "***Startup TestWrapper to initialize a regtest node and wallet***\n"
+    "#### Example 2.4.6: Start Bitcoin Core node and send coins to the taproot address\n",
+    "\n",
+    "Only run setup once, or after a clean shutdown."
    ]
   },
   {
@@ -417,15 +416,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Start node\n",
     "test = util.TestWrapper()\n",
-    "test.setup()"
+    "test.setup()\n",
+    "node = test.nodes[0]\n",
+    "\n",
+    "# Generate coins and create an output\n",
+    "tx = node.generate_and_send_coins(address)\n",
+    "print(\"Transaction {}, output 0\\nsent to {}\\n\".format(tx.hash, address))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "***Generate coins for the wallet***"
+    "#### Example 2.4.7: Construct `CTransaction` and populate fields\n",
+    "\n",
+    "We use the `create_spending_transaction(node, txid)` convenience function."
    ]
   },
   {
@@ -434,79 +441,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "test.nodes[0].generate(101)\n",
-    "balance = test.nodes[0].getbalance()\n",
-    "print('Balance: {}'.format(balance))\n",
-    "\n",
-    "assert balance > 1"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "***Send funds from the Bitcoin Core wallet to the segwit address***"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Send wallet transaction to segwit address\n",
-    "amount_btc = 0.05\n",
-    "txid = test.nodes[0].sendtoaddress(address, amount_btc)\n",
-    "\n",
-    "# Decode wallet transaction\n",
-    "tx_hex = test.nodes[0].getrawtransaction(txid) \n",
-    "decoded_tx = test.nodes[0].decoderawtransaction(tx_hex)\n",
-    "\n",
-    "print(\"Transaction:\\n{}\\n\".format(decoded_tx))\n",
-    "\n",
-    "# Reconstruct wallet transaction locally\n",
-    "tx = CTransaction()\n",
-    "tx.deserialize(BytesIO(bytes.fromhex(tx_hex)))\n",
-    "tx.rehash()\n",
-    "\n",
-    "# We can check if the transaction was correctly deserialized\n",
-    "assert txid == decoded_tx[\"txid\"]\n",
-    "\n",
-    "# The wallet randomizes the change output index for privacy\n",
-    "# Loop through the outputs and return the first where the scriptPubKey matches the segwit v1 output\n",
-    "output_index, output = next(out for out in enumerate(tx.vout) if out[1].scriptPubKey == CScript([OP_1, program]))\n",
-    "\n",
-    "print(\"Segwit v1 output is {}\".format(output))\n",
-    "print(\"Segwit v1 output value is {}\".format(output.nValue))\n",
-    "print(\"Segwit v1 output index is {}\".format(output_index))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "***Construct CTransaction and populate inputs***"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Construct transaction\n",
-    "spending_tx = CTransaction()\n",
-    "\n",
-    "# Populate the transaction version\n",
-    "spending_tx.nVersion = 1\n",
-    "\n",
-    "# Populate the locktime\n",
-    "spending_tx.nLockTime = 0\n",
-    "\n",
-    "# Populate the transaction inputs\n",
-    "outpoint = COutPoint(tx.sha256, output_index)\n",
-    "spending_tx_in = CTxIn(outpoint = outpoint)\n",
-    "spending_tx.vin = [spending_tx_in]\n",
+    "# Create a spending transaction\n",
+    "spending_tx = test.create_spending_transaction(tx.hash, version=2)\n",
     "\n",
     "print(\"Spending transaction:\\n{}\".format(spending_tx))"
    ]
@@ -515,35 +451,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "***Populate outputs***"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Generate new Bitcoin Core wallet address\n",
-    "dest_addr = test.nodes[0].getnewaddress(address_type=\"bech32\")\n",
-    "scriptpubkey = bytes.fromhex(test.nodes[0].getaddressinfo(dest_addr)['scriptPubKey'])\n",
-    "\n",
-    "# Determine minimum fee required for mempool acceptance\n",
-    "min_fee = int(test.nodes[0].getmempoolinfo()['mempoolminfee'] * 100000000)\n",
-    "\n",
-    "# Complete output which returns funds to Bitcoin Core wallet\n",
-    "amount_sat = int(amount_btc * 100000000)\n",
-    "dest_output = CTxOut(nValue=amount_sat - min_fee, scriptPubKey=scriptpubkey)\n",
-    "spending_tx.vout = [dest_output]\n",
-    "\n",
-    "print(\"Spending transaction:\\n{}\".format(spending_tx))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### _Programming Exercise 2.4.7:_ Sign the transaction for `TapLeafA` \n",
+    "#### _Programming Exercise 2.4.8:_ Sign the transaction for `TapLeafA` \n",
     "\n",
     "Note that we must pass the following arguments to `TaprootSignatureHash` for script path spending:\n",
     "* `scriptpath`: `True`\n",
@@ -558,7 +466,7 @@
    "source": [
     "# Generate the taproot signature hash for signing\n",
     "sighashA = TaprootSignatureHash(spending_tx,\n",
-    "                               [output],\n",
+    "                               [tx.vout[0]],\n",
     "                               SIGHASH_ALL_TAPROOT,\n",
     "                               input_index=0,\n",
     "                               scriptpath=  # TODO: implement\n",
@@ -573,7 +481,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### _Programming Exercise  2.4.8:_ Construct the witness, add it to the transaction and verify mempool acceptance"
+    "#### _Programming Exercise  2.4.9:_ Construct the witness, add it to the transaction and verify mempool acceptance"
    ]
   },
   {
@@ -590,11 +498,8 @@
     "witness_in.scriptWitness = witness\n",
     "spending_tx.wit.vtxinwit.append(witness_in)\n",
     "\n",
-    "# Serialize Schnorr transaction for broadcast\n",
-    "spending_tx_str = spending_tx.serialize().hex()\n",
-    "\n",
     "# Test mempool acceptance\n",
-    "assert test.nodes[0].testmempoolaccept([spending_tx_str])[0]['allowed']\n",
+    "assert node.test_transaction(spending_tx)\n",
     "print(\"Success!\")"
    ]
   },

--- a/solutions/2.1-segwit-version-1-solutions.ipynb
+++ b/solutions/2.1-segwit-version-1-solutions.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 2.1.9 _Programming Exercise:_ Generate segwit v1 addresses for a 2-of-2 MuSig aggregate pubkey"
+    "#### 2.1.7 _Programming Exercise:_ Generate segwit v1 addresses for a 2-of-2 MuSig aggregate pubkey"
    ]
   },
   {
@@ -31,7 +31,7 @@
     "# Method: address = program_to_witness(version_int, program_bytes)\n",
     "pubkey_data_musig = agg_pubkey.get_bytes()\n",
     "program_musig = bytes([pubkey_data_musig[0] & 1]) + pubkey_data_musig[1:]\n",
-    "version = 0x01\n",
+    "version = 1\n",
     "address_musig = program_to_witness(version, program_musig)\n",
     "print(\"2-of-2 musig: \", address_musig)"
    ]
@@ -40,47 +40,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 2.1.11 _Programming Exercise:_ Instantiate a CTransaction object and populate the version, locktime and inputs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Construct transaction which spends the musig segwit v1 output\n",
-    "spending_tx = CTransaction()\n",
-    "spending_tx.nVersion = 1\n",
-    "spending_tx.nLockTime = 0\n",
-    "outpoint = COutPoint(tx_musig.sha256, output_index)\n",
-    "spending_tx_in = CTxIn(outpoint = outpoint)\n",
-    "spending_tx.vin = [spending_tx_in]\n",
-    "\n",
-    "# Generate new Bitcoin Core wallet address\n",
-    "# Method: addr_string = test.nodes[0].getnewaddress(address_type=\"bech32\")\n",
-    "# Method: decode addr_string with test.nodes[0].getaddressinfo(addr_string)\n",
-    "dest_addr = test.nodes[0].getnewaddress(address_type=\"bech32\")\n",
-    "scriptpubkey = bytes.fromhex(test.nodes[0].getaddressinfo(dest_addr)['scriptPubKey'])\n",
-    "print(\"Destination address: {}\\n\".format(dest_addr))\n",
-    "\n",
-    "# Determine minimum fee required for mempool acceptance\n",
-    "min_fee = int(test.nodes[0].getmempoolinfo()['mempoolminfee'] * 100000000)\n",
-    "\n",
-    "# Complete output which returns funds to Bitcoin Core wallet\n",
-    "# Tip: Construct output with CTxOut(nValue=value_int, scriptPubKey=script_bytes)\n",
-    "# Tip: CTransaction.vout is a list of CTxOut objects.\n",
-    "amount_sat = int(amount_btc * 100000000)\n",
-    "dest_output = CTxOut(nValue=amount_sat-min_fee, scriptPubKey=scriptpubkey)\n",
-    "spending_tx.vout = [dest_output]\n",
-    "print(\"Spending transaction:\\n{}\\n\".format(spending_tx))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### 2.1.12 _Programming Exercise:_ Create a valid bip-schnorr signature for the MuSig aggregate pubkey"
+    "#### 2.1.10 _Programming Exercise:_ Create a valid bip-schnorr signature for the MuSig aggregate pubkey"
    ]
   },
   {
@@ -90,7 +50,7 @@
    "outputs": [],
    "source": [
     "# Create sighash for ALL (0x00)\n",
-    "sighash_musig = TaprootSignatureHash(spending_tx, [output], SIGHASH_ALL_TAPROOT, input_index = 0, scriptpath = False)\n",
+    "sighash_musig = TaprootSignatureHash(spending_tx, [tx.vout[0]], SIGHASH_ALL_TAPROOT, input_index=0)\n",
     "\n",
     "# Generate individual nonces for participants and an aggregate nonce point\n",
     "# Remember to negate the individual nonces if necessary\n",
@@ -119,11 +79,8 @@
     "witness_in.scriptWitness = witness\n",
     "spending_tx.wit.vtxinwit.append(witness_in)\n",
     "\n",
-    "# Serialize Schnorr transaction for broadcast\n",
-    "spending_tx_str = spending_tx.serialize().hex()\n",
-    "\n",
     "# Test mempool acceptance\n",
-    "assert test.nodes[0].testmempoolaccept([spending_tx_str])[0]['allowed']\n",
+    "assert node.test_transaction(spending_tx)\n",
     "print(\"Success!\")"
    ]
   }

--- a/solutions/2.2-taptweak-solutions.ipynb
+++ b/solutions/2.2-taptweak-solutions.ipynb
@@ -88,17 +88,17 @@
     "# Derive the bech32 address\n",
     "# Tip: set the first byte of taproot_pubkey to 0 or 1 and then call program_to_witness(version_int, pubkey_bytes)\n",
     "taproot_pubkey_v1 = bytes([taproot_pubkey_b[0] & 1]) + taproot_pubkey_b[1:]\n",
-    "segwit_address = program_to_witness(1, taproot_pubkey_v1)\n",
+    "address = program_to_witness(1, taproot_pubkey_v1)\n",
     "\n",
-    "assert segwit_address == \"bcrt1pq9lku0vuddzvcte8yvt3xct0dk6cjqeq2yzqp3vwpvh2e8afqpvqqyftl09\"\n",
-    "print(\"Success! Segwit Address: {}\".format(segwit_address))"
+    "assert address == \"bcrt1pq9lku0vuddzvcte8yvt3xct0dk6cjqeq2yzqp3vwpvh2e8afqpvqqyftl09\"\n",
+    "print(\"Success! Address: {}\".format(address))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### _Programming Exercise 2.2.6:_ Spend taproot output with key path"
+    "#### _Programming Exercise 2.2.8:_ Spend taproot output with key path"
    ]
   },
   {
@@ -107,13 +107,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Complete output which returns funds to Bitcoin Core wallet\n",
-    "dest_output = CTxOut(nValue=output_value-min_fee, scriptPubKey=scriptpubkey)\n",
-    "spending_tx.vout = [dest_output]\n",
-    "\n",
     "# Sign transaction with tweaked private key\n",
-    "# Method: TaprootSignatureHash(tx, output_list, hash_type = int, input_index = int, scriptpath = bool)\n",
-    "sighash = TaprootSignatureHash(spending_tx, [output], SIGHASH_ALL_TAPROOT)\n",
+    "# Method: TaprootSignatureHash(tx, output_list, hash_type=int, input_index=int, scriptpath=bool)\n",
+    "sighash = TaprootSignatureHash(spending_tx, [tx.vout[0]], SIGHASH_ALL_TAPROOT, input_index=0)\n",
     "tweaked_privkey = privkey.add(taptweak)\n",
     "sig = tweaked_privkey.sign_schnorr(sighash)\n",
     "\n",
@@ -124,13 +120,8 @@
     "witness_in.scriptWitness = witness\n",
     "spending_tx.wit.vtxinwit.append(witness_in)\n",
     "\n",
-    "# Serialize transaction for broadcast\n",
-    "# Method: CTransaction.serialize().hex()\n",
-    "spending_tx_str = spending_tx.serialize().hex()\n",
-    "print(\"Serialized tx: {}\\n\".format(spending_tx_str))\n",
-    "\n",
     "# Test mempool acceptance\n",
-    "assert test.nodes[0].testmempoolaccept([spending_tx_str])[0]['allowed']\n",
+    "assert node.test_transaction(spending_tx)\n",
     "print(\"Success!\")"
    ]
   }

--- a/solutions/2.3-tapscript-solutions.ipynb
+++ b/solutions/2.3-tapscript-solutions.ipynb
@@ -60,8 +60,7 @@
     "    data += input_data\n",
     "    return sha256(data)\n",
     "\n",
-    "privkey_internal = ECKey().generate()\n",
-    "pubkey_internal = privkey_internal.get_pubkey()\n",
+    "privkey_internal, pubkey_internal = generate_key_pair()\n",
     "\n",
     "# Method: ser_string(Cscript) prepends compact size.\n",
     "TAPSCRIPT_VER = bytes([0xc0])\n",
@@ -74,40 +73,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### _Programming Exercise 2.3.12:_ Construct `CTransaction` and populate inputs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Construct transaction\n",
-    "spending_tx = CTransaction()\n",
-    "\n",
-    "# Populate the transaction version\n",
-    "spending_tx.nVersion = 2\n",
-    "\n",
-    "# Populate the locktime\n",
-    "spending_tx.nLockTime = 0\n",
-    "\n",
-    "# Populate the transaction inputs\n",
-    "# Method: Construct COutPoint(txid, index)\n",
-    "# Method: Construct CTxIn(outpoint = ..., nSequence = ...)\n",
-    "# Tip: CTransaction.vin = \"list of CTxIn objects\"\n",
-    "outpoint = COutPoint(tx.sha256, output_index)\n",
-    "spending_tx_in = CTxIn(outpoint = outpoint, nSequence=delay)\n",
-    "spending_tx.vin = [spending_tx_in]\n",
-    "\n",
-    "print(\"Spending transaction:\\n{}\".format(spending_tx))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### _Programming Exercise 2.3.14:_ Sign the transaction"
+    "#### _Programming Exercise 2.3.11:_ Sign the transaction"
    ]
   },
   {
@@ -118,7 +84,7 @@
    "source": [
     "# Generate the Taproot Signature Hash for signing\n",
     "sighash = TaprootSignatureHash(spending_tx,\n",
-    "                               [output],\n",
+    "                               [tx.vout[0]],\n",
     "                               SIGHASH_ALL_TAPROOT,\n",
     "                               input_index=0,\n",
     "                               scriptpath=True,\n",
@@ -136,7 +102,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### _Programming Exercise 2.3.15:_ Add the witness and test acceptance of the transaction"
+    "#### _Programming Exercise 2.3.12:_ Add the witness and test acceptance of the transaction"
    ]
   },
   {
@@ -158,13 +124,10 @@
     "\n",
     "print(\"Spending transaction:\\n{}\\n\".format(spending_tx))\n",
     "\n",
-    "# Serialize signed transaction for broadcast\n",
-    "spending_tx_str = spending_tx.serialize().hex()\n",
-    "\n",
-    "# Test mempool acceptance with and without delay.\n",
-    "assert not test.nodes[0].testmempoolaccept([spending_tx_str])[0]['allowed']\n",
-    "test.nodes[0].generate(delay)\n",
-    "assert test.nodes[0].testmempoolaccept([spending_tx_str])[0]['allowed']\n",
+    "# Test mempool acceptance with and without delay\n",
+    "assert not node.test_transaction(spending_tx)\n",
+    "node.generate(delay)\n",
+    "assert node.test_transaction(spending_tx)\n",
     "\n",
     "print(\"Success!\")"
    ]

--- a/solutions/2.4-taptree-solutions.ipynb
+++ b/solutions/2.4-taptree-solutions.ipynb
@@ -110,7 +110,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### _Programming Exercise 2.4.7:_ Sign the transaction for `TapLeafA` "
+    "#### _Programming Exercise 2.4.8:_ Sign the transaction for `TapLeafA` "
    ]
   },
   {
@@ -121,7 +121,7 @@
    "source": [
     "# Generate the Taproot Signature Hash for signing\n",
     "sighashA = TaprootSignatureHash(spending_tx,\n",
-    "                               [output],\n",
+    "                               [tx.vout[0]],\n",
     "                               SIGHASH_ALL_TAPROOT,\n",
     "                               input_index=0,\n",
     "                               scriptpath=True,\n",
@@ -136,7 +136,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### _Programming Exercise  2.4.8:_ Construct the witness, add it to the transaction and verify mempool acceptance"
+    "#### _Programming Exercise  2.4.9:_ Construct the witness, add it to the transaction and verify mempool acceptance"
    ]
   },
   {
@@ -153,11 +153,8 @@
     "witness_in.scriptWitness = witness\n",
     "spending_tx.wit.vtxinwit.append(witness_in)\n",
     "\n",
-    "# Serialize Schnorr transaction for broadcast\n",
-    "spending_tx_str = spending_tx.serialize().hex()\n",
-    "\n",
     "# Test mempool acceptance\n",
-    "assert test.nodes[0].testmempoolaccept([spending_tx_str])[0]['allowed']\n",
+    "assert node.test_transaction(spending_tx)\n",
     "print(\"Success!\")"
    ]
   }

--- a/test_framework/script.py
+++ b/test_framework/script.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2015-2019 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Functionality to build scripts, as well as SignatureHash().
+"""Functionality to build scripts, as well as signature hash functions.
 
 This file is modified from python-bitcoinlib.
 """
@@ -626,7 +626,7 @@ def TaggedHash(tag, data):
 def GetP2SH(script):
     return CScript([OP_HASH160, hash160(script), OP_EQUAL])
 
-def SignatureHash(script, txTo, inIdx, hashtype):
+def LegacySignatureHash(script, txTo, inIdx, hashtype):
     """Consensus-correct SignatureHash
 
     Returns (hash, err) to precisely match the consensus-critical behavior of
@@ -676,11 +676,15 @@ def SignatureHash(script, txTo, inIdx, hashtype):
 
     return (hash, None)
 
+def get_p2pkh_script(pubkeyhash):
+    """Get the script associated with a P2PKH."""
+    return CScript([CScriptOp(OP_DUP), CScriptOp(OP_HASH160), pubkeyhash, CScriptOp(OP_EQUALVERIFY), CScriptOp(OP_CHECKSIG)])
+
 # TODO: Allow cached hashPrevouts/hashSequence/hashOutputs to be provided.
 # Performance optimization probably not necessary for python tests, however.
 # Note that this corresponds to sigversion == 1 in EvalScript, which is used
 # for version 0 witnesses.
-def SegwitVersion1SignatureHash(script, txTo, inIdx, hashtype, amount):
+def SegwitV0SignatureHash(script, txTo, inIdx, hashtype, amount):
 
     hashPrevouts = 0
     hashSequence = 0


### PR DESCRIPTION
Adds two convenience methods `generate_and_send_coins()` and `create_spending_transaction()`. Using those methods removes a lot of the duplicate code in the notebooks that exists simply to setup the tests.

I've added a chapter 2.0 that explains the structure of the 2.x notebooks and introduces the convenience methods. I've also updated chapter 2.1 to use the convenience methods.

If people agree that this is an improvement, I'll update 2.2, 2.3 and 2.4 to use these methods.

Fixes #92 