### PR TITLE
Chapter 2.1 example

### DIFF
--- a/2.1-segwit-version-1.ipynb
+++ b/2.1-segwit-version-1.ipynb
@@ -9,9 +9,9 @@
     "import util\n",
     "from test_framework.address import program_to_witness\n",
     "from test_framework.key import generate_key_pair, generate_schnorr_nonce\n",
-    "from test_framework.messages import CTxInWitness\n",
+    "from test_framework.messages import CTxInWitness, sha256\n",
     "from test_framework.musig import aggregate_musig_signatures, aggregate_schnorr_nonces, generate_musig_key, sign_musig\n",
-    "from test_framework.script import SIGHASH_ALL_TAPROOT, TaprootSignatureHash"
+    "from test_framework.script import CScript, CScriptOp, hash160, OP_0, OP_2, OP_CHECKMULTISIG, SegwitV0SignatureHash, SIGHASH_ALL, SIGHASH_ALL_TAPROOT, TaprootSignatureHash"
    ]
   },
   {
@@ -20,10 +20,8 @@
    "source": [
     "# 2.1 Taproot Outputs\n",
     "\n",
-    "* Part 1: Generating a segwit v1 output address\n",
-    "* Part 2: Sending funds from the Bitcoin Core wallet\n",
-    "* Part 3: Constructing a transaction to spend the segwit v1 output\n",
-    "    * Spending a segwit v1 output with a MuSig public key\n",
+    "* Part 1 (Example): Sending to and spending from a single-signer segwit v1 output\n",
+    "* Part 2 (Case Study): Migrating from a 2-of-2 P2WSH output to a MuSig segwit v1 output\n",
     "\n",
     "In this chapter, we introduce segwit v1 outputs, which are defined in [bip-taproot](https://github.com/bitcoinops/bips/blob/v0.1/bip-taproot.mediawiki). Segwit v1 outputs can be spent in two ways:\n",
     "\n",
@@ -32,16 +30,16 @@
     "\n",
     "By using the MuSig pubkey and signature aggregation protocol described in chapter 1.2, key path spending can be used to encumber an output to an n-of-n multisig policy in a way that is indistinguishable from a single-key output and spend.\n",
     "\n",
-    "The first half of this chapter shows an example of sending funds to a segwit v1 address using the Bitcoin Core wallet, and then manually constructing a transaction that spends that output using the new bip-taproot key path spending rules.\n",
+    "Part 1 of this chapter is an example of sending funds to a segwit v1 address using the Bitcoin Core wallet, and then manually constructing a transaction that spends that output using the new bip-taproot key path spending rules.\n",
     "\n",
-    "There is then a coding exercise to send funds to a MuSig aggregate pubkey address, and then construct a transaction that spends from that address using the bip-taproot key path spending rules, following the same steps as the example."
+    "Part 2 of this chapter is a case study, showing how using a segwit v1 output with MuSig can provide cost and privacy benefits over using a segwit P2WSH output."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Part 1. Generating a segwit v1 output\n",
+    "## Part 1 (Example): Single-signer segwit v1 output\n",
     "\n",
     "Segwit v1 follows the same output script pattern as segwit v0:\n",
     "\n",
@@ -105,7 +103,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Part 2. Sending funds from the Bitcoin Core wallet\n",
+    "### Sending funds from the Bitcoin Core wallet\n",
     "\n",
     "Next, we send funds to the segwit v1 address that we just generated. We'll create send the funds from a Bitcoin Core wallet, which is able to send outputs to segwit v1 addresses."
    ]
@@ -139,7 +137,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Part 3. Constructing a transaction to spend the segwit v1 output\n",
+    "### Constructing a transaction to spend the segwit v1 output\n",
     "\n",
     "We are now going to manually contruct, sign and broadcast a transaction which spends the segwit v1 output.\n",
     "\n",
@@ -252,20 +250,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Spending a segwit v1 output with a MuSig public key\n",
+    "## Part 2 (Case Study): 2-of-2 multisig\n",
     "\n",
-    "In this exercise, we'll use the Bitcoin Core wallet to create a transaction that sends to a 2-of-2 musig aggregate pubkey (segwit v1 address).\n",
+    "Alice stores her bitcoin using a combination of an offline hardware wallet and online wallet. She currently uses P2WSH 2-of-2 multisig, which has some drawbacks:\n",
     "\n",
-    "We'll then manually create a transaction that spends the MuSig output and sends an output back to the Bitcoin Core wallet. We'll use Bitcoin Core's `testmempoolaccept()` RPC method to verify that the transaction is valid."
+    "- spending a P2WSH multisig output is more expensive than spending a single signature P2WPKH output, since multiple pubkeys and signatures need to be included in the witness\n",
+    "- spending from the P2WSH output reveals that the coins were encumbered using a multisig setup. Anyone who transacted with Alice (paid or was paid by) can see this easily, and even entities who do not transact directly with Alice can discover this with some chain analysis. Revealing her wallet setup may be bad for Alice's privacy and safety.\n",
+    "\n",
+    "In this chapter, we'll show how Alice can move to using a MuSig aggregated public key, eventually saving her transaction fees and protecting her privacy."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 2.1.7 _Programming Exercise:_ Generate segwit v1 addresses for a 2-of-2 MuSig aggregate pubkey\n",
+    "### Spending a segwit v0 P2SH 2-of-2 multisig\n",
     "\n",
-    "In this exercise, we create a 2-of-2 aggregate MuSig public key"
+    "We'll first show Alice's current setup: P2WSH 2-of-2 multisig."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example 2.1.7: Construct a 2-of-2 P2WSH output\n",
+    "\n",
+    "In this example, we'll construct a 2-of-2 P2WSH output and address"
    ]
   },
   {
@@ -278,7 +288,132 @@
     "privkey1, pubkey1 = generate_key_pair()\n",
     "privkey2, pubkey2 = generate_key_pair()\n",
     "\n",
-    "# Generate a 2-of-2 aggregate MuSig key\n",
+    "# Create the spending script\n",
+    "multisig_script = CScript([CScriptOp(OP_2), pubkey1.get_bytes(), pubkey2.get_bytes(), CScriptOp(OP_2), CScriptOp(OP_CHECKMULTISIG)])\n",
+    "\n",
+    "# Hash the spending script\n",
+    "script_hash = sha256(multisig_script)\n",
+    "\n",
+    "# Generate the address\n",
+    "version = 0\n",
+    "address = program_to_witness(version, script_hash)\n",
+    "print(\"bech32 address is {}\".format(address))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example 2.1.8: Start a Bitcoind node and send funds to the segwit v0 address\n",
+    "\n",
+    "We'll use the `generate_and_send_coins()` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test = util.TestWrapper()\n",
+    "test.setup()\n",
+    "node = test.nodes[0]\n",
+    "\n",
+    "# Generate coins and create an output\n",
+    "tx = node.generate_and_send_coins(address)\n",
+    "print(\"Transaction {}, output 0\\nsent to {}\\n\".format(tx.hash, address))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example 2.1.9 : Construct CTransaction, sign and check validity\n",
+    "\n",
+    "In this example we:\n",
+    "- create a `CTransaction` object\n",
+    "- create signatures for both public keys\n",
+    "- create a valid witness using those signatures and add it to the transaction\n",
+    "- test transaction validity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a spending transaction\n",
+    "spending_tx = test.create_spending_transaction(tx.hash)\n",
+    "\n",
+    "# Generate the segwit v0 signature hash for signing\n",
+    "sighash = SegwitV0SignatureHash(script=multisig_script,\n",
+    "                                txTo=spending_tx,\n",
+    "                                inIdx=0,\n",
+    "                                hashtype=SIGHASH_ALL,\n",
+    "                                amount=100_000_000)\n",
+    "\n",
+    "# Sign using ECDSA and append the SIGHASH byte\n",
+    "sig1 = privkey1.sign_ecdsa(sighash) + chr(SIGHASH_ALL).encode('latin-1')\n",
+    "sig2 = privkey2.sign_ecdsa(sighash) + chr(SIGHASH_ALL).encode('latin-1')\n",
+    "\n",
+    "print(\"Signatures:\\n- {},\\n- {}\\n\".format(sig1.hex(), sig2.hex()))\n",
+    "\n",
+    "# Construct witness and add it to the script.\n",
+    "# For a multisig P2WSH input, the script witness is the signatures and the scipt\n",
+    "witness_elements = [b'', sig1, sig2, multisig_script]\n",
+    "spending_tx.wit.vtxinwit.append(CTxInWitness(witness_elements))\n",
+    "\n",
+    "print(\"Spending transaction:\\n{}\\n\".format(spending_tx))\n",
+    "\n",
+    "print(\"Transaction weight: {}\\n\".format(node.decoderawtransaction(spending_tx.serialize().hex())['weight']))\n",
+    "\n",
+    "# Test mempool acceptance\n",
+    "assert node.test_transaction(spending_tx)\n",
+    "print(\"Success!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example 2.1.10: Shutdown the TestWrapper (and all bitcoind instances)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test.shutdown()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Spending a segwit v1 output with a MuSig public key\n",
+    "\n",
+    "Now, we'll use Alice's same keys to create a MuSig aggregate key, and spend a segwit v1 output using that aggregate key."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 2.1.11 _Programming Exercise:_ Generate segwit v1 addresses for a 2-of-2 MuSig aggregate pubkey\n",
+    "\n",
+    "In this exercise, we create a 2-of-2 aggregate MuSig public key"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate a 2-of-2 aggregate MuSig key using the same pubkeys as before\n",
     "# Method: generate_musig_key(ECPubKey_list)\n",
     "c_map, agg_pubkey =  # TODO: implement\n",
     "\n",
@@ -299,7 +434,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Example 2.1.8: Create a transaction in the Bitcoin Core wallet sending outputs to the segwit v1 addresses"
+    "#### Example 2.1.12: Create a transaction in the Bitcoin Core wallet sending an output to the segwit v1 addresses"
    ]
   },
   {
@@ -321,7 +456,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Example 2.1.9 : Construct CTransaction and populate fields"
+    "#### Example 2.1.13 : Construct CTransaction and populate fields"
    ]
   },
   {
@@ -339,7 +474,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 2.1.10 _Programming Exercise:_ Create a valid bip-schnorr signature for the MuSig aggregate pubkey\n",
+    "#### 2.1.14 _Programming Exercise:_ Create a valid bip-schnorr signature for the MuSig aggregate pubkey\n",
     "\n",
     "In this exercise, we create a signature for the aggregate pubkey, add it to the witness, and then test that the transaction is accepted by the mempool."
    ]
@@ -372,6 +507,8 @@
     "# Add witness to transaction\n",
     "spending_tx.wit.vtxinwit.append(CTxInWitness(  # TODO: implement\n",
     "\n",
+    "# Get transaction weight\n",
+    "print(\"Transaction weight: {}\\n\".format(node.decoderawtransaction(spending_tx.serialize().hex())['weight']))\n",
     "# Test mempool acceptance\n",
     "assert node.test_transaction(spending_tx)\n",
     "print(\"Success!\")"
@@ -381,7 +518,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Example 2.1.11: Shutdown the TestWrapper (and all bitcoind instances)"
+    "### Benefits of using segwit v1 MuSig over segwit v0 P2WSH\n",
+    "\n",
+    "You can see that the transaction weight of the transaction spending the v1 MuSig output is about 30% lower than the transaction spending the v0 P2WSH output. For larger n-of-n multisig, the weight savings is even larger. Since transaction fees are based on the transaction weight, these weight savings translate directly to fee savings.\n",
+    "\n",
+    "In addition, by using a MuSig aggregate key and signature, Alice does not reveal that she is using a multisignature scheme, which is good for her privacy and security."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example 2.1.15: Shutdown the TestWrapper (and all bitcoind instances)"
    ]
   },
   {
@@ -400,9 +548,8 @@
     "**Congratulations!** In this chapter, you have:\n",
     "\n",
     "- Learned how to create a segwit v1 output and derive its bech32 address.\n",
-    "- Started a Bitcoin Core full node (in regtest mode), generated 101 blocks and sent a transaction output to the segwit v1 output.\n",
-    "- Constructed a transaction that spends the segwit v1 output back to the wallet using the key path.\n",
-    "- Repeated the above steps for a MuSig aggregate pubkey and signature."
+    "- Sent bitcoin to a segwit v1 address, and then constructed a transaction that spends the segwit v1 output back to the wallet using the key path.\n",
+    "- Shown how using a segwit v1 MuSig output saves fees and improves privacy over using P2WSH multisig."
    ]
   }
  ],

--- a/solutions/2.1-segwit-version-1-solutions.ipynb
+++ b/solutions/2.1-segwit-version-1-solutions.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 2.1.7 _Programming Exercise:_ Generate segwit v1 addresses for a 2-of-2 MuSig aggregate pubkey"
+    "#### 2.1.11 _Programming Exercise:_ Generate segwit v1 addresses for a 2-of-2 MuSig aggregate pubkey"
    ]
   },
   {
@@ -13,11 +13,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Generate individual key pairs\n",
-    "privkey1, pubkey1 = generate_key_pair()\n",
-    "privkey2, pubkey2 = generate_key_pair()\n",
-    "\n",
-    "# Generate a 2-of-2 aggregate MuSig key\n",
+    "# Generate a 2-of-2 aggregate MuSig key using the same pubkeys as before\n",
     "# Method: generate_musig_key(ECPubKey_list)\n",
     "c_map, agg_pubkey = generate_musig_key([pubkey1, pubkey2])\n",
     "\n",
@@ -40,7 +36,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 2.1.10 _Programming Exercise:_ Create a valid bip-schnorr signature for the MuSig aggregate pubkey"
+    "#### 2.1.14 _Programming Exercise:_ Create a valid bip-schnorr signature for the MuSig aggregate pubkey"
    ]
   },
   {
@@ -74,6 +70,9 @@
     "\n",
     "# Add witness to transaction\n",
     "spending_tx.wit.vtxinwit.append(CTxInWitness([sig_agg]))\n",
+    "\n",
+    "# Get transaction weight\n",
+    "print(\"Transaction weight: {}\\n\".format(node.decoderawtransaction(spending_tx.serialize().hex())['weight']))\n",
     "\n",
     "# Test mempool acceptance\n",
     "assert node.test_transaction(spending_tx)\n",


### PR DESCRIPTION
Partially addresses #86 

This adds a case study to chapter 2.1. We demonstrate a spend from a 2-of-2 P2WSH (segwit v0) output, and then compare with a spend from a MuSig segwit v1 output. This demonstrates the fee-savings and privacy benefits of using segwit v1.

@bitschmidty - let me know what you think. If you like this, we can add similar case studies to chapters 2.2 - 2.4.