### PR TITLE
Make generate_and_send_coins send rewards to bech32 address.

### DIFF
--- a/util.py
+++ b/util.py
@@ -157,8 +157,9 @@ def generate_and_send_coins(node, address):
     version = node.getnetworkinfo()['subversion']
     print("\nClient version is {}\n".format(version))
 
-    # Generate 101 blocks
-    node.generate(101)
+    # Generate 101 blocks and send reward to bech32 address
+    reward_address = node.getnewaddress(address_type="bech32")
+    node.generatetoaddress(101, reward_address)
     balance = node.getbalance()
     print("Balance: {}\n".format(balance))
 


### PR DESCRIPTION
Default `generate()` call sends rewards to P2SH(P2WPKH) output. ~~Sending rewards to a native segwit address reduces weight of spending transaction and facilitates weight comparisons between native segwit v0 and v1 transactions.~~ I would prefer minimizing transaction weights where possible.