### PR TITLE
Remove delay from witness description in 2.3

### DIFF
--- a/2.3-tapscript.ipynb
+++ b/2.3-tapscript.ipynb
@@ -367,7 +367,7 @@
     "    \n",
     "\n",
     "* `ts(csaolder(k, [key0, key1, ...], hash))`\n",
-    "    * Witness: `[signature], [signature], ..., [delay]`\n",
+    "    * Witness: `[signature], [signature], ...`\n",
     "\n",
     "\n",
     "* `ts(csahash(k, [key0, key1, ...], hash, time))`\n",
@@ -375,7 +375,7 @@
     "\n",
     "\n",
     "* `ts(csahasholder(k, [key0, key1, ...], hash, time))`\n",
-    "    * Witness: `[signature], [signature], ..., [32B pre-image], [delay]`"
+    "    * Witness: `[signature], [signature], ..., [32B pre-image]`"
    ]
   },
   {


### PR DESCRIPTION
Fixes typo in csa witness. Delay is obviously not part of the spending witness stack.