### PR TITLE
Add default stack value for CTxInWitness initializer.

### DIFF
--- a/test_framework/messages.py
+++ b/test_framework/messages.py
@@ -366,9 +366,10 @@ class CScriptWitness:
 class CTxInWitness:
     __slots__ = ("scriptWitness",)
 
-    def __init__(self, witness_stack):
+    def __init__(self, witness_stack=None):
         self.scriptWitness = CScriptWitness()
-        self.scriptWitness.stack = witness_stack
+        if witness_stack:
+            self.scriptWitness.stack = witness_stack
 
     def deserialize(self, f):
         self.scriptWitness.stack = deser_string_vector(f)


### PR DESCRIPTION
Sorry - It seems I broke CTxInWitness with a previous commit fd209df.

The previous change added a witness stack argument to the CTxInWitness initializer. However, methods such as CTransaction.deserialize() will initialize CTxInWitness() without a witness stack argument. This fix makes the witness stack argument optional.