### PR TITLE
Optional op_return output for generate_and_send_coins

### DIFF
--- a/test_framework/messages.py
+++ b/test_framework/messages.py
@@ -366,9 +366,10 @@ class CScriptWitness:
 class CTxInWitness:
     __slots__ = ("scriptWitness",)
 
-    def __init__(self, witness_stack):
+    def __init__(self, witness_stack=None):
         self.scriptWitness = CScriptWitness()
-        self.scriptWitness.stack = witness_stack
+        if witness_stack:
+            self.scriptWitness.stack = witness_stack
 
     def deserialize(self, f):
         self.scriptWitness.stack = deser_string_vector(f)

--- a/util.py
+++ b/util.py
@@ -157,8 +157,9 @@ def generate_and_send_coins(node, address):
     version = node.getnetworkinfo()['subversion']
     print("\nClient version is {}\n".format(version))
 
-    # Generate 101 blocks
-    node.generate(101)
+    # Generate 101 blocks and send reward to bech32 address
+    reward_address = node.getnewaddress(address_type="bech32")
+    node.generatetoaddress(101, reward_address)
     balance = node.getbalance()
     print("Balance: {}\n".format(balance))
 

--- a/util.py
+++ b/util.py
@@ -149,7 +149,7 @@ class TestWrapper:
     def __setattr__(self, name):
         return setattr(self.instance, name)
 
-def generate_and_send_coins(node, address):
+def generate_and_send_coins(node, address, data=None):
     """Generate blocks on node and then send 1 BTC to address.
 
     No change output is added to the transaction.
@@ -171,7 +171,10 @@ def generate_and_send_coins(node, address):
     # Create a raw transaction sending 1 BTC to the address, then sign and send it.
     # We won't create a change output, so maxfeerate must be set to 0
     # to allow any fee rate.
-    tx_hex = node.createrawtransaction(inputs=inputs, outputs=[{address: 1}])
+
+    # An OP_RETURN output is added at index 1 if data is provided.
+    outputs = [{address: 1}, {"data": data}] if data else [{address: 1}]
+    tx_hex = node.createrawtransaction(inputs=inputs, outputs=outputs)
 
     res = node.signrawtransactionwithwallet(hexstring=tx_hex)
 


### PR DESCRIPTION
Allows us to conveniently generate `op_return` outputs with `generate_and_send_coins`:
This would be useful for taptweak chapter mini case-study: #132

* Adds an optional `data` keyword to `generate_and_send_coins`:
* If `data` is set, an additional `op_return(data)` output will be created in the transaction at idx 1
* Builds on #142 (required) and #131 (optional). 

