### PR TITLE
typo: private key, not public key

### DIFF
--- a/solutions/1.1-schnorr-signatures-solutions.ipynb
+++ b/solutions/1.1-schnorr-signatures-solutions.ipynb
@@ -115,7 +115,7 @@
     "print(\"pubkey = {}\\n\".format(P.get_bytes().hex()))\n",
     "\n",
     "# Generate the nonce value k deterministically and get the nonce point R\n",
-    "# Method: use sha256(bytes) on the message and pubkey\n",
+    "# Method: use sha256(bytes) on the message and private key\n",
     "k_bytes = sha256(d.get_bytes() + msg)\n",
     "k, R = generate_key_pair(k_bytes)\n",
     "\n",


### PR DESCRIPTION
the deterministic nonce is generated by hashing the *private* [not public] key and the hash of the message.