### PR TITLE
Add Google Colab support

### DIFF
--- a/0.1-test-notebook.ipynb
+++ b/0.1-test-notebook.ipynb
@@ -24,6 +24,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Setup Google Colab environment\n",
+    "\n",
+    "This notebook should be run on [Google Colab](https://colab.research.google.com/) only. For local usage use the notebook provided [here](https://github.com/bitcoinops/taproot-workshop). \n",
+    "\n",
+    "Run the following cell to setup the Google Colab enviroment for this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!curl -o- -s -S -L https://raw.githubusercontent.com/bitcoinops/taproot-workshop/Colab/setup-colab-env.sh | bash"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "#### Verify that the bitcoind source directory is correctly configured and import the TestWrapper\n",
     "\n",
     "The source directory for your local Optech Taproot (Taproot_V0.1.4 tag) bitcoin repo should already be configured. If it isn't, update the `SOURCE_DIRECTORY` line to reference the Optech Taproot bitcoin repo directory.\n",

--- a/0.2-elliptic-curve-math.ipynb
+++ b/0.2-elliptic-curve-math.ipynb
@@ -1,6 +1,26 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Setup Google Colab environment\n",
+    "\n",
+    "This notebook should be run on [Google Colab](https://colab.research.google.com/) only. For local usage use the notebook provided [here](https://github.com/bitcoinops/taproot-workshop). \n",
+    "\n",
+    "Run the following cell to setup the Google Colab enviroment for this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!curl -o- -s -S -L https://raw.githubusercontent.com/bitcoinops/taproot-workshop/Colab/setup-colab-env.sh | bash"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/0.3-tagged-hashes.ipynb
+++ b/0.3-tagged-hashes.ipynb
@@ -1,6 +1,26 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Setup Google Colab environment\n",
+    "\n",
+    "This notebook should be run on [Google Colab](https://colab.research.google.com/) only. For local usage use the notebook provided [here](https://github.com/bitcoinops/taproot-workshop). \n",
+    "\n",
+    "Run the following cell to setup the Google Colab enviroment for this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!curl -o- -s -S -L https://raw.githubusercontent.com/bitcoinops/taproot-workshop/Colab/setup-colab-env.sh | bash"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/1.1-schnorr-signatures.ipynb
+++ b/1.1-schnorr-signatures.ipynb
@@ -1,6 +1,26 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Setup Google Colab environment\n",
+    "\n",
+    "This notebook should be run on [Google Colab](https://colab.research.google.com/) only. For local usage use the notebook provided [here](https://github.com/bitcoinops/taproot-workshop). \n",
+    "\n",
+    "Run the following cell to setup the Google Colab enviroment for this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!curl -o- -s -S -L https://raw.githubusercontent.com/bitcoinops/taproot-workshop/Colab/setup-colab-env.sh | bash"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/1.2-musig.ipynb
+++ b/1.2-musig.ipynb
@@ -1,6 +1,26 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Setup Google Colab environment\n",
+    "\n",
+    "This notebook should be run on [Google Colab](https://colab.research.google.com/) only. For local usage use the notebook provided [here](https://github.com/bitcoinops/taproot-workshop). \n",
+    "\n",
+    "Run the following cell to setup the Google Colab enviroment for this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!curl -o- -s -S -L https://raw.githubusercontent.com/bitcoinops/taproot-workshop/Colab/setup-colab-env.sh | bash"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/2.0-taproot-introduction.ipynb
+++ b/2.0-taproot-introduction.ipynb
@@ -1,6 +1,26 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Setup Google Colab environment\n",
+    "\n",
+    "This notebook should be run on [Google Colab](https://colab.research.google.com/) only. For local usage use the notebook provided [here](https://github.com/bitcoinops/taproot-workshop). \n",
+    "\n",
+    "Run the following cell to setup the Google Colab enviroment for this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!curl -o- -s -S -L https://raw.githubusercontent.com/bitcoinops/taproot-workshop/Colab/setup-colab-env.sh | bash"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/2.1-segwit-version-1.ipynb
+++ b/2.1-segwit-version-1.ipynb
@@ -1,6 +1,26 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Setup Google Colab environment\n",
+    "\n",
+    "This notebook should be run on [Google Colab](https://colab.research.google.com/) only. For local usage use the notebook provided [here](https://github.com/bitcoinops/taproot-workshop). \n",
+    "\n",
+    "Run the following cell to setup the Google Colab enviroment for this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!curl -o- -s -S -L https://raw.githubusercontent.com/bitcoinops/taproot-workshop/Colab/setup-colab-env.sh | bash"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/2.2-taptweak.ipynb
+++ b/2.2-taptweak.ipynb
@@ -1,6 +1,26 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Setup Google Colab environment\n",
+    "\n",
+    "This notebook should be run on [Google Colab](https://colab.research.google.com/) only. For local usage use the notebook provided [here](https://github.com/bitcoinops/taproot-workshop). \n",
+    "\n",
+    "Run the following cell to setup the Google Colab enviroment for this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!curl -o- -s -S -L https://raw.githubusercontent.com/bitcoinops/taproot-workshop/Colab/setup-colab-env.sh | bash"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/2.3-tapscript.ipynb
+++ b/2.3-tapscript.ipynb
@@ -1,6 +1,26 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Setup Google Colab environment\n",
+    "\n",
+    "This notebook should be run on [Google Colab](https://colab.research.google.com/) only. For local usage use the notebook provided [here](https://github.com/bitcoinops/taproot-workshop). \n",
+    "\n",
+    "Run the following cell to setup the Google Colab enviroment for this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!curl -o- -s -S -L https://raw.githubusercontent.com/bitcoinops/taproot-workshop/Colab/setup-colab-env.sh | bash"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/2.4-taptree.ipynb
+++ b/2.4-taptree.ipynb
@@ -1,6 +1,26 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Setup Google Colab environment\n",
+    "\n",
+    "This notebook should be run on [Google Colab](https://colab.research.google.com/) only. For local usage use the notebook provided [here](https://github.com/bitcoinops/taproot-workshop). \n",
+    "\n",
+    "Run the following cell to setup the Google Colab enviroment for this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!curl -o- -s -S -L https://raw.githubusercontent.com/bitcoinops/taproot-workshop/Colab/setup-colab-env.sh | bash"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/2.5-huffman.ipynb
+++ b/2.5-huffman.ipynb
@@ -1,6 +1,26 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Setup Google Colab environment\n",
+    "\n",
+    "This notebook should be run on [Google Colab](https://colab.research.google.com/) only. For local usage use the notebook provided [here](https://github.com/bitcoinops/taproot-workshop). \n",
+    "\n",
+    "Run the following cell to setup the Google Colab enviroment for this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!curl -o- -s -S -L https://raw.githubusercontent.com/bitcoinops/taproot-workshop/Colab/setup-colab-env.sh | bash"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/3.1-degrading-multisig-case-study.ipynb
+++ b/3.1-degrading-multisig-case-study.ipynb
@@ -1,6 +1,26 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Setup Google Colab environment\n",
+    "\n",
+    "This notebook should be run on [Google Colab](https://colab.research.google.com/) only. For local usage use the notebook provided [here](https://github.com/bitcoinops/taproot-workshop). \n",
+    "\n",
+    "Run the following cell to setup the Google Colab enviroment for this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!curl -o- -s -S -L https://raw.githubusercontent.com/bitcoinops/taproot-workshop/Colab/setup-colab-env.sh | bash"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/setup-colab-env.sh
+++ b/setup-colab-env.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -ue
+
+# Check if script is run inside Google Colab.
+[ -z "$COLAB_GPU" ] && echo "Exiting: Seems like you are not running this script inside Google Colab." && exit 1;
+
+# Load the custom `bitcoind` binary.
+wget -q -O colab-binary.tar.xz https://github.com/bitcoinops/bitcoin/releases/download/Taproot_V0.1.4/colab-binary.tar.xz
+tar xf colab-binary.tar.xz
+chmod +x bitcoind
+mkdir -p /content/bitcoin/src
+mv bitcoind /content/bitcoin/src
+
+# Setup the functional test config.ini.
+mkdir -p /content/bitcoin/test
+cat >/content/bitcoin/test/config.ini <<EOL
+# Copyright (c) 2013-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# These environment variables are set by the build process and read by
+# test/functional/test_runner.py and test/util/bitcoin-util-test.py
+
+[environment]
+PACKAGE_NAME=Bitcoin Core
+SRCDIR=/content/bitcoin
+BUILDDIR=/content/bitcoin
+EXEEXT=
+RPCAUTH=/content/bitcoin/share/rpcauth/rpcauth.py
+
+[components]
+# Which components are enabled. These are commented out by configure if they were disabled when running config.
+#ENABLE_WALLET=true
+#ENABLE_CLI=true
+ENABLE_BITCOIND=true
+#ENABLE_FUZZ=true
+ENABLE_ZMQ=true
+EOL
+
+
+# Clone the Optech Taproot Workshop and setup the config.ini + enviroment.
+git clone -q https://github.com/bitcoinops/taproot-workshop.git
+cp /content/taproot-workshop/util.py /content
+cp /content/taproot-workshop/requirements.txt /content
+cp /content/taproot-workshop/config.ini /content
+cp -r /content/taproot-workshop/test_framework /content
+sed -i '$ d' /content/config.ini
+echo "SOURCE_DIRECTORY=/content/bitcoin/" >> /content/config.ini
+pip3 install -r /content/requirements.txt > /dev/null
+
+echo "Colab environment setup."


### PR DESCRIPTION
*This is a pull request to the `Colab` branch, not the `master` branch*.

This PR adds support for [Google Colab](https://colab.research.google.com/) - a free Jupyter Notebook runner in the Google cloud - to the Taproot workshop notebooks. This provides users with a completely ready-to-code environment for the workshop in less than 30 seconds and thus greatly reduces the friction of the setup process. Code written by a user is automatically saved to the users Google account.

This functionality is split up into two commits. 
1. commit: Adds a shell script that sets up the Google Colab environment by e.g. cloning the Optech Bitcoin Core fork and the Taproot workshop repositories, downloading a statically-linked, Colab-compatible and taproot-enabled `bitcoind` binary (only use this binary on Colab!) and writing some config files.
2. commit: Adds two cells to the top of each existing notebook. The first with a *markdown* description for the second *code* cell. The *code* cell downloads the shell script from the first commit and executes it to set up the environment. 

Reviewing this by trying out the notebooks as-is is not possible. The notebooks try to load the shell script added in the first commit. Reviewing modifying the shell script URL to point to my feature-branch (`https://raw.githubusercontent.com/0xB10C/taproot-workshop/2019-11-add-colab-setup/setup-colab-env.sh`). A sophisticated reviewer could try to complete other notebooks than the `0.1-test-notebook.ipynb`, which has been tested in multiple PoCs before. For example `2.0-taproot-introduction.ipynb`.

Example notebooks on my feature branch:
- [`0.1-test-notebook.ipynb` on Colab](https://colab.research.google.com/github/0xB10C/taproot-workshop/blob/2019-11-add-colab-setup/0.1-test-notebook.ipynb)
- [`0.2-elliptic-curve-math.ipynb` on Colab](https://colab.research.google.com/github/0xB10C/taproot-workshop/blob/2019-11-add-colab-setup/0.2-elliptic-curve-math.ipynb)
- [`2.0-taproot-introduction.ipynb` on Colab](https://colab.research.google.com/github/0xB10C/taproot-workshop/blob/2019-11-add-colab-setup/2.0-taproot-introduction.ipynb)
- ... (copy link and change filename for other notebook)

closes #145 


> now I myself don't have an excuse to not do the workshop anymore..