### PR TITLE
s/bech32m/bech32/ for v0 address in ex2.1.7

### DIFF
--- a/2.1-segwit-version-1.ipynb
+++ b/2.1-segwit-version-1.ipynb
@@ -290,7 +290,7 @@
     "# Generate the address\n",
     "version = 0\n",
     "address = program_to_witness(version, script_hash)\n",
-    "print(\"bech32m address is {}\".format(address))"
+    "print(\"bech32 address is {}\".format(address))"
    ]
   },
   {


### PR DESCRIPTION
Fixes label in example 2.1.7.  Should be bech32 for a v0 address.