### PR TITLE
updates for bitcoin core 23.0 compatibility

### DIFF
--- a/0.1-test-notebook.ipynb
+++ b/0.1-test-notebook.ipynb
@@ -88,7 +88,7 @@
    "source": [
     "#### Check node version\n",
     "\n",
-    "This command checks the version of the Bitcoin Core node. Note that `getnetworkinfo` and `getblockchaininfo` are simply Bitcoin Core RPC commands.\n",
+    "This command checks the version of the Bitcoin Core node. Note that `getnetworkinfo` and `getdeploymentinfo` are simply Bitcoin Core RPC commands.\n",
     "\n",
     "If it fails, then the bitcoind binary is not the right version and does not have taproot enabled."
    ]
@@ -103,9 +103,9 @@
     "print(\"Client version is {}\".format(version))\n",
     "assert \"Satoshi\" in version\n",
     "\n",
-    "blockchain_info = test.nodes[0].getblockchaininfo()\n",
-    "assert 'taproot' in blockchain_info['softforks']\n",
-    "assert blockchain_info['softforks']['taproot']['active']"
+    "deployment_info = test.nodes[0].getdeploymentinfo()\n",
+    "assert 'taproot' in deployment_info['deployments']\n",
+    "assert deployment_info['deployments']['taproot']['active']"
    ]
   },
   {

--- a/test_framework/test_framework.py
+++ b/test_framework/test_framework.py
@@ -345,7 +345,7 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         if wallet_name is not False:
             n = self.nodes[i]
             if wallet_name is not None:
-                n.createwallet(wallet_name=wallet_name, load_on_startup=True)
+                n.createwallet(wallet_name=wallet_name, load_on_startup=True, descriptors=False)
             n.importprivkey(privkey=n.get_deterministic_priv_key().key, label='coinbase')
 
     def run_test(self):


### PR DESCRIPTION
here are a couple of updates to allow these notebooks to work with bitcoin core 23.0 (and the current master branch if building locally).

first, descriptor wallets are now the default wallet type. so, we need to set descriptors to false during wallet creation in order to be able to import private keys.

second, the soft fork status info has been moved from getblockchaininfo to getdeploymentinfo.