### PR TITLE
added descriptors false flag

### DIFF
--- a/test_framework/test_framework.py
+++ b/test_framework/test_framework.py
@@ -345,7 +345,7 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         if wallet_name is not False:
             n = self.nodes[i]
             if wallet_name is not None:
-                n.createwallet(wallet_name=wallet_name, load_on_startup=True)
+                n.createwallet(wallet_name=wallet_name, load_on_startup=True, descriptors=False)
             n.importprivkey(privkey=n.get_deterministic_priv_key().key, label='coinbase')
 
     def run_test(self):


### PR DESCRIPTION
The notebook depends on using legacy wallets instead of descriptor wallets. If using the latter, the `BitcoinTestFramework` class fails on line 349:

```
n.importprivkey(privkey=n.get_deterministic_priv_key().key, label='coinbase')
```

Since Bitcoin Core v23, descriptor wallets became the default, and therefore the notebook fails, unless you add a `descriptors=False` argument to the `createwallet` call. I suggest you either merge this PR or mention in the readme that the notebook requires v21 <= Bitcoin Core version < v23.