### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ $ python3 -m venv .venv && source .venv/bin/activate
 Install dependencies:
 
 ```
-$ pip3 install -r requirements.txt
+$ python3 -m pip install -r requirements.txt
 ```
 
 Ensure jupyter notebook is installed:


### PR DESCRIPTION
Use `python3 -m pip install -r requirements.txt` instead of `pip3 install -r requirements` to make sure we are installing the requirements into the active virtual environment and not just the user's outer installation of python.