### PR TITLE
Update for v26.0 compatibility

### DIFF
--- a/util.py
+++ b/util.py
@@ -96,6 +96,11 @@ class TestWrapper:
             self.options.usecli = usecli
             self.options.perf = perf
             self.options.randomseed = randomseed
+            # With v26.0 BDB wallet creation is deprecated
+            # this re-enables it temporarily
+            # TODO: create descriptor wallets as legacy wallet
+            # support will be removed in a future realease
+            self.extra_args = [['-deprecatedrpc=create_bdb']]
 
             self.options.bitcoind = bitcoind
             self.options.bitcoincli = bitcoincli


### PR DESCRIPTION
Currently, on the initial setup, when new wallets are being created, you get the following error:
> JSONRPCException: BDB wallet creation is deprecated and will be removed in a future release. In this release it can be re-enabled temporarily with the -deprecatedrpc=create_bdb setting. (-4)

With v26.0 BDB wallet creation is deprecated, making the existing code not functional.
This re-enables it using the  `-deprecatedrpc=create_bdb` flag.