### PR TITLE
Bump minimum version to 23, since 22 and below don't have getdeployme…

### DIFF
--- a/0.2-elliptic-curve-math.ipynb
+++ b/0.2-elliptic-curve-math.ipynb
@@ -187,10 +187,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "a = random.randrange(SECP256K1_ORDER / 2, SECP256K1_ORDER)\n",
+    "a = random.randrange(SECP256K1_ORDER // 2, SECP256K1_ORDER)\n",
     "a_key = ECKey().set(a) \n",
     "\n",
-    "b = random.randrange(SECP256K1_ORDER / 2, SECP256K1_ORDER)\n",
+    "b = random.randrange(SECP256K1_ORDER // 2, SECP256K1_ORDER)\n",
     "b_key = ECKey().set(b) \n",
     "\n",
     "# Left: Compute a + b as ints (modulo the sepc256k1 group order)\n",

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ $ git clone https://github.com/bitcoinops/taproot-workshop.git
 
 #### Build a taproot-supporting bitcoind
 
-These workbooks require a `bitcoind` with version 0.21 or later which supports schnorr and taproot.
+These workbooks require a `bitcoind` with version 23.0.0 or later which supports schnorr and taproot.
 
 ![workshop_repositories](images/repositories.jpg)
 


### PR DESCRIPTION
Bump minimum version to [v23](https://bitcoincore.org/en/doc/23.0.0/rpc/blockchain/getdeploymentinfo), since [v22](https://bitcoincore.org/en/doc/22.0.0/)  and below don't have the `getdeploymentinfo` RPC being called from [0.1-test-notebook.ipynb](https://github.com/bitcoinops/taproot-workshop/blob/master/0.1-test-notebook.ipynb?short_path=cdb5d14#L106).  
  

Also, `random.randrange(SECP256K1_ORDER / 2, SECP256K1_ORDER)` is throwing:
> TypeError: 'float' object cannot be interpreted as an integer
